### PR TITLE
Populate images with aws s3

### DIFF
--- a/src/app/admin/businesses/[id]/page.tsx
+++ b/src/app/admin/businesses/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import ResponsiveLayout from "@/components/layout/ResponsiveLayout";
 import AboutCard from "@/components/ui/AboutCard";
 import BusinessInfoCard from "@/components/ui/BusinessInfoCard";
@@ -11,25 +11,31 @@ import { useBusinessById, useUser } from "@/lib/swrHooks";
 import { extractBusinessDisplayData } from "@/lib/formatters";
 import { Button } from "@/components/ui/button";
 
-export default function AdminBusinessDetailPage({ params }: { params: { id: string } }) {
-  const router = useRouter();
+export default function BusinessDetailsPage() {
   const [isClient, setIsClient] = useState(false);
+  const router = useRouter();
+  const params = useParams();
+  const businessId = params?.id as string;
 
-  // Check if we're in the browser
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+  // Default image URLs for fallbacks
+  const defaultLogo = "/logo/Default_Logo.jpg";
+  const defaultBanner = "/logo/Default_Banner.png";
 
-  // Fetch user data to verify admin role
+  // Check user authentication
   const { user, isLoading: isUserLoading } = useUser();
 
-  // Fetch business data by ID
-  const { business, isLoading: isBusinessLoading } = useBusinessById(params.id);
+  // Fetch business data
+  const { business, isLoading: isBusinessLoading } = useBusinessById(businessId);
 
   // Process business data for display
   const displayData = extractBusinessDisplayData(business);
 
-  // Redirect non-admin users to appropriate page
+  // Handle client-side rendering
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  // Handle authentication checks
   useEffect(() => {
     if (!isClient) return;
 
@@ -45,22 +51,22 @@ export default function AdminBusinessDetailPage({ params }: { params: { id: stri
   }, [user, isUserLoading, isClient, router]);
 
   // Loading state
-  if (isUserLoading || isBusinessLoading) {
+  if (isBusinessLoading || !isClient) {
     return (
       <ResponsiveLayout title="Business Details">
-        <div className="w-full min-h-screen bg-white pt-8 px-6">
-          <div className="container mx-auto max-w-7xl">
-            <div className="flex justify-between items-center mb-6">
-              <h2 className="text-xl font-medium">Loading business details...</h2>
-            </div>
-            <div className="animate-pulse space-y-6">
-              <div className="h-40 bg-gray-200 rounded"></div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="h-80 bg-gray-200 rounded"></div>
-                <div className="h-80 bg-gray-200 rounded"></div>
-              </div>
-            </div>
-          </div>
+        <div className="flex justify-center items-center min-h-screen">
+          <p className="text-gray-500">Loading business details...</p>
+        </div>
+      </ResponsiveLayout>
+    );
+  }
+
+  // Handle business not found
+  if (!business) {
+    return (
+      <ResponsiveLayout title="Business Details">
+        <div className="flex justify-center items-center min-h-screen">
+          <p className="text-gray-500">Business not found.</p>
         </div>
       </ResponsiveLayout>
     );
@@ -70,25 +76,6 @@ export default function AdminBusinessDetailPage({ params }: { params: { id: stri
   const handleBackClick = () => {
     router.push("/admin");
   };
-
-  // Handle not found state
-  if (!displayData) {
-    return (
-      <ResponsiveLayout title="Business Not Found">
-        <div className="container mx-auto max-w-7xl pt-8 px-6">
-          <div className="text-center py-10">
-            <h2 className="text-2xl font-medium text-gray-700 mb-4">Business Not Found</h2>
-            <p className="text-gray-500 mb-6">
-              The business you&apos;re looking for doesn&apos;t exist or you don&apos;t have permission to view it.
-            </p>
-            <Button onClick={handleBackClick} className="bg-[#405BA9] text-white px-6 py-2 rounded-full">
-              Back to Dashboard
-            </Button>
-          </div>
-        </div>
-      </ResponsiveLayout>
-    );
-  }
 
   return (
     <ResponsiveLayout title="Business Details">
@@ -105,19 +92,35 @@ export default function AdminBusinessDetailPage({ params }: { params: { id: stri
           </div>
         </div>
 
-        {/* Business Banner */}
+        {/* Cover Image Section */}
         <section className="relative w-full h-[193px]" style={{ backgroundColor: "#293241" }}>
-          <Image src="/logo/Default_Banner.png" alt="Business Cover" fill style={{ objectFit: "cover" }} priority />
+          <Image
+            src={business?.bannerUrl || defaultBanner}
+            alt="Business Cover"
+            fill
+            style={{ objectFit: "cover" }}
+            priority
+            onError={(e) => {
+              // Fallback to default on error
+              const target = e.target as HTMLImageElement;
+              target.src = defaultBanner;
+            }}
+          />
 
-          {/* Business Logo */}
+          {/* Profile Logo */}
           <div className="absolute bottom-[-75px] left-[65px]">
             <div className="relative w-[150px] h-[150px] rounded-full border-4 border-white bg-white overflow-hidden shadow-md">
               <Image
-                src="/logo/Default_Logo.jpg"
+                src={business?.logoUrl || defaultLogo}
                 alt="Business Logo"
                 fill
                 style={{ objectFit: "contain" }}
                 className="p-2"
+                onError={(e) => {
+                  // Fallback to default on error
+                  const target = e.target as HTMLImageElement;
+                  target.src = defaultLogo;
+                }}
               />
             </div>
           </div>
@@ -125,24 +128,20 @@ export default function AdminBusinessDetailPage({ params }: { params: { id: stri
 
         {/* Content Section */}
         <div className="container mx-auto px-6 md:px-8 max-w-7xl mt-28">
-          {/* Business Name Header */}
-          <section className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8">
-            <div>
-              <h2 className="text-2xl font-bold">{displayData.businessInfo.name}</h2>
-              <p className="text-gray-600">{displayData.businessInfo.type}</p>
-            </div>
-            <p className="text-sm text-zinc-500 mt-2 md:mt-0">Member since {displayData.membership.memberSince}</p>
+          {/* Business Name Section */}
+          <section className="flex flex-col md:flex-row justify-between items-start md:items-center mb-5">
+            <h2 className="text-2xl">{displayData?.businessInfo.name || "Business Name"}</h2>
           </section>
 
           {/* About Section */}
           <div className="mb-6 w-full">
-            <AboutCard info={{ description: displayData.about.description }} editable={false} />
+            <AboutCard info={{ description: displayData?.about.description || "" }} editable={false} />
           </div>
 
           {/* Information Cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8 lg:gap-16 mb-10">
-            <BusinessInfoCard info={displayData.businessInfo} editable={false} />
-            <ContactInfoCard info={displayData.contactInfo} editable={false} />
+            <BusinessInfoCard info={displayData?.businessInfo} editable={false} />
+            <ContactInfoCard info={displayData?.contactInfo} editable={false} />
           </div>
         </div>
       </main>

--- a/src/app/admin/requests/page.tsx
+++ b/src/app/admin/requests/page.tsx
@@ -70,16 +70,16 @@ export default function AdminRequestsPage() {
 
   // Calculate stats based on requests data
   const stats = {
-    pending: requests?.filter((req) => req.status === undefined).length || 0,
-    approved: requests?.filter((req) => req.status === "approved").length || 0,
-    declined: requests?.filter((req) => req.status === "denied").length || 0,
+    pending: requests?.filter((req) => req.status === "open").length || 0,
+    approved: requests?.filter((req) => req.decision === "approved").length || 0,
+    declined: requests?.filter((req) => req.decision === "denied").length || 0,
   };
 
   // Apply filter to pending requests
   const filterPendingRequests = () => {
     if (!requests) return [];
 
-    const pendingRequests = requests.filter((req) => req.status === undefined);
+    const pendingRequests = requests.filter((req) => req.status === "open");
     const sorted = [...pendingRequests];
 
     switch (pendingFilter) {
@@ -100,7 +100,7 @@ export default function AdminRequestsPage() {
   const filterHistoryRequests = () => {
     if (!requests) return [];
 
-    const historyRequests = requests.filter((req) => req.status === "approved" || req.status === "denied");
+    const historyRequests = requests.filter((req) => req.status === "closed");
     const sorted = [...historyRequests];
 
     switch (historyFilter) {
@@ -232,7 +232,7 @@ export default function AdminRequestsPage() {
                       <RequestCard
                         type="history"
                         businessName={getBusinessName(request)}
-                        status={request.status as "approved" | "denied"}
+                        status={request.decision as "approved" | "denied"}
                         date={formatDate(request.date)}
                         className="w-full"
                       />

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -23,7 +23,7 @@ export default function BusinessDashboardPage() {
   const [showEditForm, setShowEditForm] = useState(false);
   const [showEditBiz, setShowEditBiz] = useState(false);
   const [showEditContact, setShowEditContact] = useState(false);
-  const [showEditBanner, setShowEditBanner] = useState(false);
+  const [showEditBannerAndLogo, setShowEditBannerAndLogo] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -36,6 +36,10 @@ export default function BusinessDashboardPage() {
 
   // Process business data for display
   const displayData = extractBusinessDisplayData(business);
+
+  // Default image URLs for fallbacks
+  const defaultLogo = "/logo/Default_Logo.jpg";
+  const defaultBanner = "/logo/Default_Banner.png";
 
   // Handle loading state
   useEffect(() => {
@@ -50,11 +54,11 @@ export default function BusinessDashboardPage() {
   };
 
   const handleEditBannerClick = () => {
-    setShowEditBanner(true);
+    setShowEditBannerAndLogo(true);
   };
 
   const handleEditBannerClose = () => {
-    setShowEditBanner(false);
+    setShowEditBannerAndLogo(false);
   };
 
   const handleEditBizClick = () => {
@@ -85,6 +89,13 @@ export default function BusinessDashboardPage() {
     mutate();
   };
 
+  const handleBannerAndLogoSubmit = () => {
+    setShowEditBannerAndLogo(false); // Close the banner modal
+    setShowConfirmation(true); // Show confirmation
+    // Refresh business data
+    mutate();
+  };
+
   // Handle confirmation close
   const handleConfirmationClose = () => {
     setShowConfirmation(false);
@@ -107,7 +118,18 @@ export default function BusinessDashboardPage() {
       <main className="w-full bg-white min-h-screen overflow-x-hidden pb-[142px]">
         {/* Cover Image Section */}
         <section className="relative w-full h-[193px]" style={{ backgroundColor: "#293241" }}>
-          <Image src="/logo/Default_Banner.png" alt="Business Cover" fill style={{ objectFit: "cover" }} priority />
+          <Image
+            src={business?.bannerUrl || defaultBanner}
+            alt="Business Cover"
+            fill
+            style={{ objectFit: "cover" }}
+            priority
+            onError={(e) => {
+              // Fallback to default on error
+              const target = e.target as HTMLImageElement;
+              target.src = defaultBanner;
+            }}
+          />
 
           {/* Edit Banner Button */}
           <button
@@ -122,11 +144,16 @@ export default function BusinessDashboardPage() {
           <div className="absolute bottom-[-75px] left-[65px]">
             <div className="relative w-[150px] h-[150px] rounded-full border-4 border-white bg-white overflow-hidden shadow-md">
               <Image
-                src="/logo/Default_Logo.jpg"
+                src={business?.logoUrl || defaultLogo}
                 alt="Business Logo"
                 fill
                 style={{ objectFit: "contain" }}
                 className="p-2"
+                onError={(e) => {
+                  // Fallback to default on error
+                  const target = e.target as HTMLImageElement;
+                  target.src = defaultLogo;
+                }}
               />
             </div>
           </div>
@@ -169,14 +196,14 @@ export default function BusinessDashboardPage() {
         </div>
       </main>
 
-      {/* Edit Banner Modal */}
-      {showEditBanner && (
+      {/* Edit Banner and Logo Modal */}
+      {showEditBannerAndLogo && (
         <div className="fixed inset-x-0 top-0 bottom-[92px] z-[60] h-[calc(100vh-92px)] bg-black bg-opacity-50 flex w-full items-start sm:items-center justify-center overflow-y-auto sm:inset-0 sm:h-auto sm:p-4">
           <ChangeBannerAndLogo
             onClose={handleEditBannerClose}
-            onSubmitSuccess={handleEditSubmit}
-            initialBannerUrl="/logo/Default_Banner.png"
-            initialLogoUrl="/logo/Default_Logo.jpg"
+            onSubmitSuccess={handleBannerAndLogoSubmit}
+            initialBannerUrl={business?.bannerUrl || defaultBanner}
+            initialLogoUrl={business?.logoUrl || defaultLogo}
           />
         </div>
       )}

--- a/src/components/layout/DesktopHero.tsx
+++ b/src/components/layout/DesktopHero.tsx
@@ -2,12 +2,25 @@
 
 import React from "react";
 import Image from "next/image";
+import { useUser } from "@clerk/nextjs";
+import { useBusiness } from "@/lib/swrHooks";
 
 interface DesktopHeroProps {
   title: string;
 }
 
 const DesktopHero = ({ title }: DesktopHeroProps) => {
+  // Get user data and role
+  const { user } = useUser();
+  const userRole = user?.publicMetadata?.role as string;
+
+  // Only fetch business data if user is a business
+  const { business } = useBusiness(userRole === "business" ? user?.id : null);
+
+  // Default logo to use if no business logo is available
+  const defaultLogo = "/logo/HBA_NoBack_NoWords.png";
+  const profileLogo = userRole === "business" && business?.logoUrl ? business.logoUrl : defaultLogo;
+
   return (
     <div className="flex justify-between items-center py-4 px-6">
       {/* TITLE: Page heading with consistent styling */}
@@ -24,11 +37,16 @@ const DesktopHero = ({ title }: DesktopHeroProps) => {
         <div className="flex items-center gap-[10px]">
           <div className="w-[50px] h-[50px] rounded-full border border-[#00000036] flex items-center justify-center overflow-hidden">
             <Image
-              src="/logo/HBA_NoBack_NoWords.png"
+              src={profileLogo}
               alt="Profile"
               width={50}
               height={50}
               className="rounded-full object-cover"
+              onError={(e) => {
+                // Fallback to default on error
+                const target = e.target as HTMLImageElement;
+                target.src = defaultLogo;
+              }}
             />
           </div>
           <Image src="/icons/Expand Arrow.png" alt="Expand" width={25} height={25} className="cursor-pointer" />

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -30,7 +30,7 @@ export default function DesktopSidebar() {
   const userRole = user?.publicMetadata?.role as string;
 
   // Default logo to use if no business logo is available
-  const defaultLogo = "/logo/Default_Logo.jpg";
+  const defaultLogo = "/logo/HBA_NoBack_NoWords.png";
   const businessLogo = shouldFetchBusiness && business?.logoUrl ? business.logoUrl : defaultLogo;
 
   if (!isLoaded) return null;

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -29,6 +29,10 @@ export default function DesktopSidebar() {
   const { business } = useBusiness(clerkId);
   const userRole = user?.publicMetadata?.role as string;
 
+  // Default logo to use if no business logo is available
+  const defaultLogo = "/logo/Default_Logo.jpg";
+  const businessLogo = shouldFetchBusiness && business?.logoUrl ? business.logoUrl : defaultLogo;
+
   if (!isLoaded) return null;
 
   const handleSignOut = async () => {
@@ -151,7 +155,7 @@ export default function DesktopSidebar() {
             </Link>
           ))}
 
-          {/* ✅ Sign Out Button below the nav items */}
+          {/* Sign Out Button below the nav items */}
           <button
             onClick={handleSignOut}
             className={cn(
@@ -175,11 +179,16 @@ export default function DesktopSidebar() {
         >
           <div className={cn("flex", isExpanded ? "items-center pl-[12px] h-[66px]" : "p-[18px]")}>
             <Image
-              src="/logo/HBA_NoBack_NoWords.png"
+              src={userRole === "business" ? businessLogo : defaultLogo}
               alt="Business Logo"
               width={62}
               height={57}
               className="object-contain"
+              onError={(e) => {
+                // Fallback to default on error
+                const target = e.target as HTMLImageElement;
+                target.src = defaultLogo;
+              }}
             />
             {isExpanded && (
               <span className="ml-[18px] text-white font-futura text-base font-medium leading-[21.25px]">

--- a/src/components/ui/InformationCard.tsx
+++ b/src/components/ui/InformationCard.tsx
@@ -29,6 +29,8 @@ interface BusinessInfo {
   };
   description?: string;
   logo?: string;
+  logoUrl?: string;
+  bannerUrl?: string;
 }
 
 interface InformationCardProps {
@@ -40,6 +42,10 @@ interface InformationCardProps {
 }
 
 const InformationCard = ({ type, businessInfo, className, otherBusinessInfo }: InformationCardProps) => {
+  // Default image URLs for fallbacks
+  const defaultLogo = "/logo/Default_Logo.jpg";
+  const defaultBanner = "/logo/Default_Banner.png";
+
   // Helper function to check if a value has changed
   const isValueChanged = (current: any, other: any): boolean => {
     // If either value is undefined, we only care if they're different
@@ -55,6 +61,10 @@ const InformationCard = ({ type, businessInfo, className, otherBusinessInfo }: I
     // For primitive values, direct comparison
     return current !== other;
   };
+
+  // Check if logo or banner has changed
+  const hasLogoChanged = isValueChanged(businessInfo.logoUrl, otherBusinessInfo?.logoUrl);
+  const hasBannerChanged = isValueChanged(businessInfo.bannerUrl, otherBusinessInfo?.bannerUrl);
 
   // Format and style text based on if it has changed
   const formatFieldValue = (fieldValue: any, otherFieldValue: any, defaultText: string = "N/A") => {
@@ -307,6 +317,57 @@ const InformationCard = ({ type, businessInfo, className, otherBusinessInfo }: I
       )}
     >
       <div className="p-4 sm:p-6">
+        {/* Banner Image Section - New at top */}
+        <div className="mb-4">
+          <p className="font-futura font-bold text-[12px] leading-[16px] text-[#8C8C8C] w-full mb-1">Banner</p>
+          <div
+            className={cn(
+              "relative w-full h-[80px] rounded-md overflow-hidden p-1",
+              hasBannerChanged ? (type === "old" ? "bg-red-100" : "bg-green-100") : "bg-white",
+            )}
+          >
+            <div className="relative w-full h-full rounded-md overflow-hidden">
+              <Image
+                src={businessInfo.bannerUrl || defaultBanner}
+                alt="Business Banner"
+                fill
+                style={{ objectFit: "cover" }}
+                onError={(e) => {
+                  // Fallback to default on error
+                  const target = e.target as HTMLImageElement;
+                  target.src = defaultBanner;
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Logo Image Section - New at top */}
+        <div className="mb-4">
+          <p className="font-futura font-bold text-[12px] leading-[16px] text-[#8C8C8C] w-full mb-1">Logo</p>
+          <div
+            className={cn(
+              "relative w-[100px] h-[100px] rounded-full border-4 border-white overflow-hidden shadow-sm p-2",
+              hasLogoChanged ? (type === "old" ? "bg-red-100" : "bg-green-100") : "bg-white",
+            )}
+          >
+            <div className="relative w-full h-full rounded-full overflow-hidden">
+              <Image
+                src={businessInfo.logoUrl || defaultLogo}
+                alt="Business Logo"
+                fill
+                style={{ objectFit: "contain" }}
+                className="p-2"
+                onError={(e) => {
+                  // Fallback to default on error
+                  const target = e.target as HTMLImageElement;
+                  target.src = defaultLogo;
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
         {/* Business Information Section */}
         <div className="relative">
           {/* Business Name */}
@@ -365,24 +426,6 @@ const InformationCard = ({ type, businessInfo, className, otherBusinessInfo }: I
           {/* Description with GitHub-style highlighting */}
           <p className="font-futura font-bold text-[12px] leading-[16px] text-[#8C8C8C] w-full mb-1">Description</p>
           <div className="w-full mb-4">{formatDescription()}</div>
-        </div>
-
-        {/* Logo Section - Positioned on the side on larger screens, below on mobile */}
-        <div className="mt-6 w-full sm:absolute sm:top-[96px] sm:right-6 sm:w-[137px]">
-          <p className="font-futura font-bold text-[12px] leading-[16px] text-[#8C8C8C] mb-2">Logo</p>
-          <div className="w-full h-[131px] sm:w-[137px] sm:h-[131px] bg-gray-100 flex items-center justify-center">
-            {businessInfo.logo ? (
-              <Image src={businessInfo.logo} alt="Business Logo" width={130} height={124} className="object-contain" />
-            ) : (
-              <Image
-                src="/logo/HBA_NoBack_NoWords.png"
-                alt="Default Logo"
-                width={130}
-                height={124}
-                className="object-contain"
-              />
-            )}
-          </div>
         </div>
       </div>
     </Card>

--- a/src/database/requestSchema.ts
+++ b/src/database/requestSchema.ts
@@ -26,7 +26,10 @@ export type IRequest = {
   };
   description: string;
   date: Date;
-  status?: "approved" | "denied";
+  status?: "open" | "closed";
+  decision?: null | "approved" | "denied";
+  logoUrl?: string;
+  bannerUrl?: string;
 };
 
 // Create the Mongoose schema for Business details.
@@ -55,7 +58,10 @@ const RequestSchema = new Schema<IRequest>({
   },
   description: { type: String, required: false },
   date: { type: Date, required: false, default: Date.now },
-  status: { type: String, enum: ["approved", "denied"] },
+  status: { type: String, enum: ["open", "closed"], default: "open" },
+  decision: { type: String, enum: ["approved", "denied"], default: null },
+  logoUrl: { type: String },
+  bannerUrl: { type: String },
 });
 
 // Export the model.

--- a/src/lib/swrHooks.ts
+++ b/src/lib/swrHooks.ts
@@ -116,13 +116,34 @@ export function useRequest(id: string, config?: SWRConfiguration) {
 }
 
 /**
+ * Hook for fetching current business user's active request (open)
+ */
+export function useActiveBusinessRequest(config?: SWRConfiguration) {
+  const { data, error, isLoading, isValidating, mutate } = useSWR<IRequest>("/api/request?status=open", {
+    revalidateOnFocus: false,
+    ...config,
+  });
+
+  // If we get an array from the API, take the first request (should be only one)
+  const activeRequest = Array.isArray(data) ? data[0] : data;
+
+  return {
+    activeRequest,
+    isLoading,
+    isValidating,
+    isError: error,
+    mutate,
+  };
+}
+
+/**
  * Utility to manually mutate cached request data
  * Useful for optimistic updates when approving/denying requests
  */
-export function updateRequestStatus(id: string, status: "approved" | "denied", cache: IRequest[]) {
+export function updateRequestStatus(id: string, status: "closed", decision: "approved" | "denied", cache: IRequest[]) {
   return cache?.map((request) =>
     // Using string indexing since _id might not be in the interface but exists in MongoDB documents
-    (request as any)._id === id ? { ...request, status } : request,
+    (request as any)._id === id ? { ...request, status, decision } : request,
   );
 }
 


### PR DESCRIPTION
## Developer: Kevin Rutledge

Closes #75

### Pull Request Summary
Add S3 image integration to display business logos and banners. It includes dynamic loading based on user roles and proper fallback.

Note:
Some commits were intended for issue #77, but CI Build required those files to be committed first. For the full package just merge my next PR.

### Modifications
- `src/app/business/page.tsx`: Added dynamic banner and logo loading from S3 with fallbacks
- `src/app/admin/businesses/[id]/page.tsx`: Implemented banner and logo display with error handling
- `src/app/admin/requests/[id]/page.tsx`: Added image comparison for both old and new logos/banners
- `src/components/layout/DesktopHero.tsx`: Added business logo in profile based on user role
- `src/components/layout/DesktopSidebar.tsx`: Added business logo in footer when user is a business
- `src/components/ui/ChangeBannerAndLogo.tsx`: Enhanced to handle existing requests and update instead of creating new ones
- `src/components/ui/InformationCard.tsx`: Added visual comparison of banner and logo changes in request cards

### Testing Considerations
- Verified images load correctly with proper fallbacks to default images when S3 images aren't available
- Tested across different user roles (admin vs business) to ensure correct images display
- Confirmed error handling works properly when images fail to load
- Validated that comparison views correctly highlight image changes between old and new versions
- Tested integration with existing request workflow for updating images

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

desktop:
![image](https://github.com/user-attachments/assets/43c3c530-a05e-41c8-a09b-b70ffdeedb9b)

desktop change banner and logo shows current mongo image or fallback:
![image](https://github.com/user-attachments/assets/6e0a9545-fc4e-4c4f-9286-030d8ce5bd38)

mobile:
![image](https://github.com/user-attachments/assets/e0fd4dfe-a4e3-41ca-a66d-f89fda535337)

mobile change banner and logo shows current mongo image or fallback:
![image](https://github.com/user-attachments/assets/f00b07fd-f50c-4bf0-9b18-672bfee02abd)
