### PR TITLE
fixed spacing issue with mobile botton navbar

### DIFF
--- a/src/components/layout/MobileBottomNav.tsx
+++ b/src/components/layout/MobileBottomNav.tsx
@@ -36,19 +36,17 @@ export default function Navbar() {
   return (
     <div className="fixed inset-x-0 bottom-0 z-50 bg-[#D9D9D9] shadow-lg h-[92px] overflow-x-hidden">
       <NavigationMenu className="w-full !max-w-full flex mt-[11px]">
-        <NavigationMenuList className="w-full flex justify-center items-center">
+        <NavigationMenuList className="w-full flex justify-evenly items-center">
           {/* CONTAINER: Fixed width container ensures consistent spacing between items */}
-          <div className="flex justify-between items-center w-[302px]">
-            {userRole &&
-              menuItems[userRole]?.map((item, index) => (
-                <NavigationMenuItem key={index} className="flex justify-center">
-                  <NavigationMenuLink href={item.href} className="flex flex-col items-center">
-                    {/* IMAGE: Maintains original dimensions for proper display */}
-                    <Image src={item.src} alt={item.alt} width={item.width} height={item.height} />
-                  </NavigationMenuLink>
-                </NavigationMenuItem>
-              ))}
-          </div>
+          {userRole &&
+            menuItems[userRole]?.map((item, index) => (
+              <NavigationMenuItem key={index} className="flex">
+                <NavigationMenuLink href={item.href} className="flex flex-col items-center">
+                  {/* IMAGE: Maintains original dimensions for proper display */}
+                  <Image src={item.src} alt={item.alt} width={item.width} height={item.height} />
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            ))}
         </NavigationMenuList>
       </NavigationMenu>
     </div>

--- a/src/components/layout/navigation-menu.tsx
+++ b/src/components/layout/navigation-menu.tsx
@@ -11,11 +11,13 @@ const NavigationMenu = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <NavigationMenuPrimitive.Root
     ref={ref}
-    className={cn("relative z-10 flex max-w-max flex-1 items-center justify-center", className)}
+    className={cn("relative z-10 flex w-full items-center justify-center", className)}
     {...props}
   >
-    {children}
-    <NavigationMenuViewport />
+    <div className="relative w-full">
+      {children}
+      <NavigationMenuViewport />
+    </div>
   </NavigationMenuPrimitive.Root>
 ));
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;


### PR DESCRIPTION
## Developer: Andrew Munoz Arvizu

Closes #102

### Pull Request Summary

Fixed the spacing of the icons in the mobile bottom bar so that its no longer hardcoded.

### Modifications

MobileBottomNav.tsx, navigation-menu.tsx

Removed the outer div that had the hardcoded function, making sure that the items are spread evenly.
Changed the primitive so that it takes up the entire width of the block.

### Testing Considerations
Shrunk the screen and made sure that it stayed consistent as it was changed to different widths.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/d207faa9-694b-46e6-b1ed-943907078359)
