### PR TITLE
Allow Windows EOF to pass linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,11 @@
   "extends": ["next/core-web-vitals", "prettier"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Developer: Xavier Garcia

### No associated Issue

### Pull Request Summary

In` .eslintrc.json`, I allowed prettier to accept endOfLine characters other than just LF. This allows for the Windows EOF character CRLF to not cause linting errors.

### Modifications
.eslintrc.json was slightly altered

### Testing Considerations
After the change, I ran `npm run lint --fix`, which failed before but didn't this time.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
Before: 
![image](https://github.com/user-attachments/assets/f6ae1611-27a9-4a40-bcc1-c0a9e40551e4)

After: 
![image](https://github.com/user-attachments/assets/3096ad39-ecdb-4589-88eb-4828f7fd74cb)
