### PR TITLE
79 business signup mobile views

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,11 @@
   "extends": ["next/core-web-vitals", "prettier"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -2,8 +2,8 @@ import BusinessSignupApplication from "@/components/ui/BusinessSignupApplication
 
 export default function Page() {
   return (
-    <main className="flex justify-center items-center min-h-screen bg-[#293241] gap-x-28">
+    <div className="flex h-screen items-center justify-center bg-[#293241]">
       <BusinessSignupApplication />
-    </main>
+    </div>
   );
 }

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -2,7 +2,7 @@ import BusinessSignupApplication from "@/components/ui/BusinessSignupApplication
 
 export default function Page() {
   return (
-    <main className="flex justify-center items-center min-h-screen bg-[#293241] gap-x-28 pb-20">
+    <main className="flex justify-center items-center min-h-screen bg-[#293241] gap-x-28">
       <BusinessSignupApplication />
     </main>
   );

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { Input } from "./input";
 import { Button } from "./button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./dropdown-menu";
+import { Eye, EyeOff } from "lucide-react";
 
 interface BusinessSignupAppInfo {
   contactInfo: { name: string; phone: string; email: string };
@@ -87,7 +88,7 @@ const BusinessSignupApplication = () => {
     "Phone Number* (XXX) XXX-XXXX",
     "Email Address*",
     "Enter Password*",
-    "Renter Password*",
+    "Re-enter Password*",
   ];
   const spanishContactInfo = [
     "Nombre de Contacto*",
@@ -119,6 +120,17 @@ const BusinessSignupApplication = () => {
   const [step, setStep] = useState(1);
   const [password1, setPassword1] = useState("");
   const [password2, setPassword2] = useState("");
+  const [showPassword1, setShowPassword1] = useState(false);
+  const [showPassword2, setShowPassword2] = useState(false);
+
+  // Toggle password visibilities
+  const togglePassword1Visibility = () => {
+    setShowPassword1(!showPassword1);
+  };
+  const togglePassword2Visibility = () => {
+    setShowPassword2(!showPassword2);
+  };
+
   const {
     register,
     formState: { errors },
@@ -357,7 +369,9 @@ const BusinessSignupApplication = () => {
               />
 
               {formErrorMessage && (
-                <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+                <div className="text-red-600 w-full md:pr-[4.3em] md:mt-[-0.5em] text-center md:text-start">
+                  {formErrorMessage}
+                </div>
               )}
             </div>
 
@@ -412,7 +426,7 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
 
-              <div className="flex items-center mt-[-8px] mb-[-25px] text-[13px]">
+              <div className="flex items-center mt-[-8px] text-[13px]">
                 <label htmlFor="sameAddress" className="flex items-center">
                   <input
                     type="checkbox"
@@ -426,7 +440,7 @@ const BusinessSignupApplication = () => {
               </div>
 
               {!isMailingAddressSame && (
-                <div className="grid gap-4 mt-5">
+                <div className="grid gap-4 mt-[-0.25em]">
                   <Input
                     key={`mailingAddress-Addr-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -473,7 +487,9 @@ const BusinessSignupApplication = () => {
                 </div>
               )}
               {formErrorMessage && (
-                <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+                <div className="text-red-600 w-full md:pr-[4.3em] md:mt-[-0.5em] text-center md:text-start">
+                  {formErrorMessage}
+                </div>
               )}
             </div>
 
@@ -512,7 +528,7 @@ const BusinessSignupApplication = () => {
       case 4:
         return (
           <div className="w-[90%] mr-auto ml-auto">
-            <div className="grid gap-4 mt-5">
+            <div className="grid gap-3">
               <Input
                 key={`contactName-${step}`}
                 className="w-full border-[#8C8C8C]"
@@ -552,33 +568,56 @@ const BusinessSignupApplication = () => {
                 })}
               />
 
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-6">
-                  <Input
-                    key={`password1-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="password"
-                    id="Password1"
-                    value={password1}
-                    placeholder={contactInfoFieldNames[langOption][3]}
-                    onChange={(e) => setPassword1(e.target.value)}
-                  />
-                </div>
-                <div className="col-span-6">
-                  <Input
-                    key={`password2-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="password"
-                    id="Password2"
-                    value={password2}
-                    placeholder={contactInfoFieldNames[langOption][4]}
-                    onChange={(e) => setPassword2(e.target.value)}
-                  />
-                </div>
+              <div className="relative w-full">
+                <Input
+                  key={`password1-${step}`}
+                  className="w-full border-[#8C8C8C] pr-[4.3em]"
+                  type={showPassword1 ? "text" : "password"}
+                  id="Password1"
+                  value={password1}
+                  placeholder={contactInfoFieldNames[langOption][3]}
+                  onChange={(e) => setPassword1(e.target.value)}
+                />
+                <button
+                  type="button"
+                  onClick={togglePassword1Visibility}
+                  className="absolute right-3 top-1/2 -translate-y-1/2"
+                >
+                  {showPassword1 ? (
+                    <EyeOff className="h-5 w-5 text-gray-400" />
+                  ) : (
+                    <Eye className="h-5 w-5 text-gray-400" />
+                  )}
+                </button>
+              </div>
+
+              <div className="relative w-full">
+                <Input
+                  key={`password2-${step}`}
+                  className="w-full border-[#8C8C8C] pr-[4.3em]"
+                  type={showPassword2 ? "text" : "password"}
+                  id="Password2"
+                  value={password2}
+                  placeholder={contactInfoFieldNames[langOption][4]}
+                  onChange={(e) => setPassword2(e.target.value)}
+                />
+                <button
+                  type="button"
+                  onClick={togglePassword2Visibility}
+                  className="absolute right-3 top-1/2 -translate-y-1/2"
+                >
+                  {showPassword2 ? (
+                    <EyeOff className="h-5 w-5 text-gray-400" />
+                  ) : (
+                    <Eye className="h-5 w-5 text-gray-400" />
+                  )}
+                </button>
               </div>
             </div>
             {formErrorMessage && (
-              <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+              <div className="text-red-600 w-full md:pr-[4.3em] md:mt-[-0.5em] text-center md:text-start pt-2">
+                {formErrorMessage}
+              </div>
             )}
             {renderNavButtons(true, true)}
           </div>
@@ -599,7 +638,7 @@ const BusinessSignupApplication = () => {
               </div>
             </div>
             <div className="w-full md:w-[65%] flex mx-auto">{renderStepForm()}</div>
-            <div className="md:hidden flex mx-auto mt-[4%]">
+            <div className="md:hidden flex mx-auto mt-[8%]">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -678,7 +717,7 @@ const BusinessSignupApplication = () => {
         </Card>
         <div className="hidden md:block md:flex md:flex-row md:justify-start">
           <DropdownMenu>
-            <DropdownMenuTrigger>
+            <DropdownMenuTrigger asChild>
               <Button
                 className="bg-[#293241] text-white hover:text-blue-500 hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
                 type="button"

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -553,7 +553,7 @@ const BusinessSignupApplication = () => {
 
   if (step < 5) {
     return (
-      <div className="w-full md:max-w-[70vw] md:h-auto overflow-hidden">
+      <div className="w-full md:max-w-[70vw] md:h-auto">
         <Card className="relative md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
           <CardContent className="flex flex-col md:flex-row h-full md:h-[320px] mt-[15px] p-1">
             <div className="w-auto md:w-[35%] flex flex-col items-start text-left p-4">
@@ -564,6 +564,23 @@ const BusinessSignupApplication = () => {
               </div>
             </div>
             <div className="w-full md:w-[65%] flex mx-auto">{renderStepForm()}</div>
+            <div className="md:hidden flex mx-auto mt-[4%]">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    className="bg-[#293241] text-white hover:text-blue-500 hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
+                    type="button"
+                  >
+                    {langOptions[langOption]}
+                    <Image src="/icons/Sort Down.png" alt="DropDownArrow" width={15} height={15} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onClick={() => changeLanguage(0)}>{langOptions[0]}</DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => changeLanguage(1)}>{langOptions[1]}</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </CardContent>
         </Card>
         <div className="hidden md:block md:flex md:flex-row md:justify-start">
@@ -587,15 +604,16 @@ const BusinessSignupApplication = () => {
     );
   } else {
     return (
-      <div className="w-full h-screen md:max-w-[70vw] md:h-auto overflow-hidden">
+      <div className="w-full md:max-w-[70vw] md:h-auto">
         <Card className="relative shadow-none md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
-          <CardContent className="flex flex-col w-full h-[320px] mt-[15px] items-center">
+          {/* <CardContent className="flex flex-col w-full h-[320px] mt-[15px] items-center"> */}
+          <CardContent className="md:flex-row h-full md:h-[320px] mt-[15px] items-center p-4">
             <div className="w-full flex items-start p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
             </div>
             <div className="flex flex-col justify-center items-center w-full h-[60%]">
               <Image src="/icons/Request Approved.png" alt="Checkmark" width={60} height={60} />
-              <strong className="text-[18px]">{submissionTitle[langOption]}</strong>
+              <strong className="text-[18px] text-center">{submissionTitle[langOption]}</strong>
               <h5>{submissionSubtitle[langOption]}</h5>
               <div className="bg-[#3F5EBB] text-white p-4 rounded-lg mt-4">
                 <ol className="list-decimal list-inside space-y-2 text-left text-[14px]">
@@ -604,6 +622,23 @@ const BusinessSignupApplication = () => {
                   <li>{submissionSteps[langOption][2]}</li>
                 </ol>
               </div>
+            </div>
+            <div className="md:hidden flex mx-auto justify-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    className="bg-[#293241] text-white hover:text-blue-500 hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
+                    type="button"
+                  >
+                    {langOptions[langOption]}
+                    <Image src="/icons/Sort Down.png" alt="DropDownArrow" width={15} height={15} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onClick={() => changeLanguage(0)}>{langOptions[0]}</DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => changeLanguage(1)}>{langOptions[1]}</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </CardContent>
         </Card>

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -335,20 +335,18 @@ const BusinessSignupApplication = () => {
         );
       case 2:
         return (
-          <div className="w-[90%] mt-[8%] mr-auto ml-auto">
+          <div className="w-[90%] mr-auto ml-auto">
             <div className="grid gap-4 mt-5">
+              <Input
+                key={`physicalAddress-Addr-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="PhysicalAddress-Addr"
+                placeholder={businessInfoFieldNames[langOption][5]}
+                {...register("businessInfo.physicalAddress.street", { required: "Address is required" })}
+              />
               <div className="grid grid-cols-12 gap-2">
                 <div className="col-span-5">
-                  <Input
-                    key={`physicalAddress-Addr-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="PhysicalAddress-Addr"
-                    placeholder={businessInfoFieldNames[langOption][5]}
-                    {...register("businessInfo.physicalAddress.street", { required: "Address is required" })}
-                  />
-                </div>
-                <div className="col-span-3">
                   <Input
                     key={`physicalAddress-City-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -358,7 +356,7 @@ const BusinessSignupApplication = () => {
                     {...register("businessInfo.physicalAddress.city", { required: "City is required" })}
                   />
                 </div>
-                <div className="col-span-2">
+                <div className="col-span-4">
                   <Input
                     key={`physicalAddress-State-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -368,7 +366,7 @@ const BusinessSignupApplication = () => {
                     {...register("businessInfo.physicalAddress.state", { required: "State is required" })}
                   />
                 </div>
-                <div className="col-span-2">
+                <div className="col-span-3">
                   <Input
                     key={`physicalAddress-ZIP-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -383,31 +381,23 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
 
-              <div className="grid grid-cols-12 gap-2 text-[13px]">
-                <div className="col-span-10 flex items-center mt-[-8px] mb-[-8px]">
-                  <label htmlFor="sameAddress" className="flex items-center">
-                    <input
-                      type="checkbox"
-                      id="sameAddress"
-                      onChange={(e) => setIsMailingAddressSame(e.target.checked)}
-                    />
-                    {businessInfoFieldNames[langOption][10]}
-                  </label>
-                </div>
+              <div className="flex items-center mt-[-8px] mb-[-8px] text-[13px]">
+                <label htmlFor="sameAddress" className="flex items-center">
+                  <input type="checkbox" id="sameAddress" onChange={(e) => setIsMailingAddressSame(e.target.checked)} />
+                  {businessInfoFieldNames[langOption][10]}
+                </label>
               </div>
 
+              <Input
+                key={`mailingAddress-Addr-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="MailAddress-Addr"
+                placeholder={businessInfoFieldNames[langOption][6]}
+                {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
+              />
               <div className="grid grid-cols-12 gap-2">
                 <div className="col-span-5">
-                  <Input
-                    key={`mailingAddress-Addr-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="MailAddress-Addr"
-                    placeholder={businessInfoFieldNames[langOption][6]}
-                    {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
-                  />
-                </div>
-                <div className="col-span-3">
                   <Input
                     key={`mailingAddress-City-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -417,7 +407,7 @@ const BusinessSignupApplication = () => {
                     {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
                   />
                 </div>
-                <div className="col-span-2">
+                <div className="col-span-4">
                   <Input
                     key={`mailingAddress-State-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -427,7 +417,7 @@ const BusinessSignupApplication = () => {
                     {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
                   />
                 </div>
-                <div className="col-span-2">
+                <div className="col-span-3">
                   <Input
                     key={`mailingAddress-ZIP-${step}`}
                     className="w-full border-[#8C8C8C]"

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -193,6 +193,9 @@ const BusinessSignupApplication = () => {
   const nextStep = () => {
     switch (step) {
       case 1: // business information page
+        validateData();
+        break;
+      case 2: // address information
         if (isMailingAddressSame) {
           // Copy values from physical address to mailing address if checkbox is checked
           setValue("businessInfo.mailingAddress.street", getValues("businessInfo.physicalAddress.street"));
@@ -200,9 +203,6 @@ const BusinessSignupApplication = () => {
           setValue("businessInfo.mailingAddress.state", getValues("businessInfo.physicalAddress.state"));
           setValue("businessInfo.mailingAddress.zip", getValues("businessInfo.physicalAddress.zip"));
         }
-        validateData();
-        break;
-      case 2: // address information
         validateData();
         break;
       case 3: // social links page
@@ -333,7 +333,7 @@ const BusinessSignupApplication = () => {
         );
       case 2:
         return (
-          <div>
+          <div className="w-[90%] mt-[8%] mr-auto ml-auto">
             <div className="grid gap-4 mt-5">
               <div className="grid grid-cols-12 gap-2">
                 <div className="col-span-4">
@@ -342,7 +342,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="PhysicalAddress-Addr"
-                    placeholder={businessInfoFieldNames[langOption][2]}
+                    placeholder={businessInfoFieldNames[langOption][5]}
                     {...register("businessInfo.physicalAddress.street", { required: "Address is required" })}
                   />
                 </div>
@@ -352,7 +352,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="PhysicalAddress-City"
-                    placeholder={businessInfoFieldNames[langOption][4]}
+                    placeholder={businessInfoFieldNames[langOption][7]}
                     {...register("businessInfo.physicalAddress.city", { required: "City is required" })}
                   />
                 </div>
@@ -362,7 +362,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="PhysicalAddress-State"
-                    placeholder={businessInfoFieldNames[langOption][5]}
+                    placeholder={businessInfoFieldNames[langOption][8]}
                     {...register("businessInfo.physicalAddress.state", { required: "State is required" })}
                   />
                 </div>
@@ -372,7 +372,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="PhysicalAddress-ZIP"
-                    placeholder={businessInfoFieldNames[langOption][6]}
+                    placeholder={businessInfoFieldNames[langOption][9]}
                     {...register("businessInfo.physicalAddress.zip", {
                       required: "ZIP is required",
                       pattern: { value: /^\d{5}$/, message: "ZIP code must be exactly 5 digits" },
@@ -389,7 +389,7 @@ const BusinessSignupApplication = () => {
                       id="sameAddress"
                       onChange={(e) => setIsMailingAddressSame(e.target.checked)}
                     />
-                    {businessInfoFieldNames[langOption][7]}
+                    {businessInfoFieldNames[langOption][10]}
                   </label>
                 </div>
               </div>
@@ -401,7 +401,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="MailAddress-Addr"
-                    placeholder={businessInfoFieldNames[langOption][3]}
+                    placeholder={businessInfoFieldNames[langOption][6]}
                     {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
                   />
                 </div>
@@ -411,7 +411,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="MailAddress-City"
-                    placeholder={businessInfoFieldNames[langOption][4]}
+                    placeholder={businessInfoFieldNames[langOption][7]}
                     {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
                   />
                 </div>
@@ -421,7 +421,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="MailAddress-State"
-                    placeholder={businessInfoFieldNames[langOption][5]}
+                    placeholder={businessInfoFieldNames[langOption][8]}
                     {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
                   />
                 </div>
@@ -431,7 +431,7 @@ const BusinessSignupApplication = () => {
                     className="w-full border-[#8C8C8C]"
                     type="text"
                     id="MailAddress-ZIP"
-                    placeholder={businessInfoFieldNames[langOption][6]}
+                    placeholder={businessInfoFieldNames[langOption][9]}
                     {...register("businessInfo.mailingAddress.zip", { required: "ZIP is required" })}
                   />
                 </div>
@@ -555,7 +555,7 @@ const BusinessSignupApplication = () => {
     }
   };
 
-  if (step < 4) {
+  if (step < 5) {
     return (
       <div className="w-[70vw] h-[300px]">
         <Card className="relative bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] rounded-lg">

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -11,15 +11,35 @@ import { Button } from "./button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./dropdown-menu";
 
 interface BusinessSignupAppInfo {
-  contactInfo: { name: string; title: string; phoneNumber?: string; cellNumber?: string; email: string };
-  businessInfo: {
+  contactInfo: {
     name: string;
-    websiteURL?: string;
-    numEmployees?: string;
-    physicalAddress: { address: string; city: string; state: string; zip: string };
-    mailingAddress: { address: string; city: string; state: string; zip: string };
+    phone: string;
+    email: string;
   };
-  socialLinks: { Instagram?: string; X?: string; Facebook?: string; LinkedIn?: string };
+  businessInfo: {
+    businessName: string;
+    website: string;
+    businessOwner: string;
+    businessType: string;
+    description: string;
+    physicalAddress: {
+      street: string;
+      city: string;
+      state: string;
+      zip: string;
+    };
+    mailingAddress: {
+      street: string;
+      city: string;
+      state: string;
+      zip: string;
+    };
+  };
+  socialLinks: {
+    IG?: string;
+    X?: string;
+    FB?: string;
+  };
 }
 
 const BusinessSignupApplication = () => {
@@ -36,19 +56,21 @@ const BusinessSignupApplication = () => {
   // page subtitles by language
   const englishPageSubtitles = [
     "Business Information",
-    "Contact Information",
+    "Business Information",
     "Social Links",
     "Payment Information",
     "Payment Method",
+    "Contact Information",
   ];
   const spanishPageSubtitles = [
     "Información Comercial",
-    "Información del Contacto",
+    "Información Comercial",
     "Enlaces Sociales",
     "Información de Pago",
     "Método de Pago",
+    "Información del Contacto",
   ];
-  const numPages = 6;
+  const numPages = 7;
   const pageSubtitles = [englishPageSubtitles, spanishPageSubtitles];
 
   // for navigation buttons
@@ -61,6 +83,9 @@ const BusinessSignupApplication = () => {
   const englishBusinessInfo = [
     "Business Name*",
     "Website URL*",
+    "Business Type*",
+    "Name of Business Owner*",
+    "Description of the Business*",
     "Physical Address*",
     "Mailing Address*",
     "City*",
@@ -71,6 +96,9 @@ const BusinessSignupApplication = () => {
   const spanishBusinessInfo = [
     "Nombre Comercial*",
     "URL del Sitio Web*",
+    "Tipo de Negocio*",
+    "Nombre del Propietario del Negocio*",
+    "Descripción del Negocio*",
     "Dirección Física*",
     "Dirección de Envio",
     "Ciudad*",
@@ -83,31 +111,19 @@ const BusinessSignupApplication = () => {
   // for contact info page
   const englishContactInfo = [
     "Contact Name*",
-    "Title*",
     "Phone Number* (XXX) XXX-XXXX",
-    "Cell Phone Number (XXX) XXX-XXXX",
     "Email Address*",
+    "Enter Password*",
+    "Renter Password*",
   ];
   const spanishContactInfo = [
     "Nombre de Contacto*",
-    "Título*",
     "Número de Teléfono* (XXX) XXX-XXXX",
-    "Número de Teléfono Celular (XXX) XXX-XXXX",
     "Dirección de Correo Electrónico*",
+    "Ingrese la Contraseña*",
+    "Escriba la Contraseña Otra Vez*",
   ];
   const contactInfoFieldNames = [englishContactInfo, spanishContactInfo];
-
-  // for payment method / card info
-  const englishPaymentInfo = ["Name on Card*", "Billing Address*", "Billing ZIP*", "Card Number*", "MM/YY*", "CVC*"];
-  const spanishPaymentInfo = [
-    "Nombre en la Tarjeta*",
-    "Dirección de Envio*",
-    "Código Postal de Facturación*",
-    "Número de Tarjeta*",
-    "MM/YY*",
-    "CVC*",
-  ];
-  const paymentInfoFieldNames = [englishPaymentInfo, spanishPaymentInfo];
 
   // for app submission page
   const submissionTitle = ["Application Submitted", "Solicitud Enviada"];
@@ -136,14 +152,14 @@ const BusinessSignupApplication = () => {
     trigger,
   } = useForm<BusinessSignupAppInfo>({
     defaultValues: {
-      contactInfo: { name: "", title: "", phoneNumber: "", cellNumber: "", email: "" },
+      contactInfo: { name: "", phone: "", email: "" },
       businessInfo: {
-        name: "",
-        websiteURL: "",
-        physicalAddress: { address: "", city: "", state: "", zip: "" },
-        mailingAddress: { address: "", city: "", state: "", zip: "" },
+        businessName: "",
+        website: "",
+        physicalAddress: { street: "", city: "", state: "", zip: "" },
+        mailingAddress: { street: "", city: "", state: "", zip: "" },
       },
-      socialLinks: { Instagram: "", Facebook: "", X: "", LinkedIn: "" },
+      socialLinks: { IG: "", FB: "", X: "" },
     },
   });
 
@@ -153,45 +169,6 @@ const BusinessSignupApplication = () => {
     if (firstErrorMessage !== "") {
       setFirstErrorMessage(errorMsgs[val]);
     }
-  };
-
-  // for fourth page: Payment Information
-  const displayPaymentInfo = () => {
-    const englishPlans = ["Annual Membership Investment", "Ribbon Cutting", "Additional Category"];
-    const spanishPlans = ["Inversión Anual de Membresía", "Corte de Cinta", "Categoría Adicional"];
-    const langPlans = [englishPlans, spanishPlans];
-
-    const pricesInOrder = ["$250", "$50", "$20"];
-
-    if (step == 4) {
-      return (
-        <div className="flex flex-row w-[92%] h-[full] bg-[#3F5EBB] text-white p-1 rounded-lg mt-4 text-[14px]">
-          {/* <div className="flex flex-row justify-between p-1 w-full"> */}
-          <div className="flex flex-col items-start w-[80%] pl-2">
-            <p>{langPlans[langOption][0]}</p>
-            <p>{langPlans[langOption][1]}</p>
-            <p>{langPlans[langOption][2]}</p>
-          </div>
-          <div className="flex flex-col items-end w-[20%] pr-2">
-            <p>{pricesInOrder[0]}</p>
-            <p>{pricesInOrder[1]}</p>
-            <p>{pricesInOrder[2]}</p>
-          </div>
-          {/* </div> */}
-        </div>
-      );
-    } else {
-      return <div></div>;
-    }
-  };
-
-  const formatMoneyValue = (input: string) => {
-    // Remove $ and commas
-    const cleaned = input.replace(/[$,]/g, "");
-    // Ensure valid float format
-    const floatVal = parseFloat(cleaned);
-    // Return as string with two decimal places
-    return isNaN(floatVal) ? "" : floatVal.toFixed(2);
   };
 
   // validate form entries
@@ -245,7 +222,7 @@ const BusinessSignupApplication = () => {
       case 1: // business information page
         if (isMailingAddressSame) {
           // Copy values from physical address to mailing address if checkbox is checked
-          setValue("businessInfo.mailingAddress.address", getValues("businessInfo.physicalAddress.address"));
+          setValue("businessInfo.mailingAddress.street", getValues("businessInfo.physicalAddress.street"));
           setValue("businessInfo.mailingAddress.city", getValues("businessInfo.physicalAddress.city"));
           setValue("businessInfo.mailingAddress.state", getValues("businessInfo.physicalAddress.state"));
           setValue("businessInfo.mailingAddress.zip", getValues("businessInfo.physicalAddress.zip"));
@@ -326,6 +303,64 @@ const BusinessSignupApplication = () => {
     switch (step) {
       case 1:
         return (
+          // <div>
+          //   <div className="grid gap-4 mt-[20px] justify-start items-start">
+          //     <div>
+          //       <Input
+          //         key={`businessName-${step}`}
+          //         className="w-[550px] border-[#8C8C8C]"
+          //         type="text"
+          //         id="BusinessName"
+          //         placeholder={businessInfoFieldNames[langOption][0]}
+          //         {...register("businessInfo.businessName", { required: "Business name is required" })}
+          //       />
+          //     </div>
+
+          //     <div>
+          //       <Input
+          //         key={`websiteURL-${step}`}
+          //         className="w-[550px] border-[#8C8C8C]"
+          //         type="text"
+          //         id="WebsiteURL"
+          //         placeholder={businessInfoFieldNames[langOption][1]}
+          //         {...register("businessInfo.website", { required: "Website URL is required" })}
+          //       />
+          //     </div>
+
+          //     <div className="flex items-center gap-2">
+          //       <Input
+          //         key={`businessType-${step}`}
+          //         className="w-[275px] border-[#8C8C8C]"
+          //         type="text"
+          //         id="businessType"
+          //         placeholder={businessInfoFieldNames[langOption][2]}
+          //         {...register("businessInfo.businessType", { required: "Business Type is required" })}
+          //       />
+          //       <Input
+          //         key={`businessOwner-${step}`}
+          //         className="w-[275px] border-[#8C8C8C]"
+          //         type="text"
+          //         id="businessOwner"
+          //         placeholder={businessInfoFieldNames[langOption][3]}
+          //         {...register("businessInfo.businessOwner", { required: "Business Owner is required" })}
+          //       />
+          //     </div>
+
+          //     <div>
+          //       <Input
+          //         key={`description-${step}`}
+          //         className="w-[550px] border-[#8C8C8C]"
+          //         type="text"
+          //         id="description"
+          //         placeholder={businessInfoFieldNames[langOption][4]}
+          //         {...register("businessInfo.description", { required: "Description is required" })}
+          //       />
+          //     </div>
+          //     {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
+          //   </div>
+          //   {renderNavButtons(false, false)}
+          // </div>
+
           <div>
             <div className="grid gap-4 mt-5">
               <div className="grid grid-cols-12 gap-2">
@@ -591,122 +626,9 @@ const BusinessSignupApplication = () => {
           </div>
         );
       case 4:
-        // NOTE: There may be code below that is not currently used because field is
-        // not required until we have a payment system set up.
-        return (
-          <div className="w-full flex flex-col items-start justify-start">
-            <Input
-              key={`amountPaid-${step}`}
-              className="w-[350px] border-[#8C8C8C] mt-[140px] ml-[40px]"
-              type="text"
-              id="AmountPaid"
-              placeholder={langOption == 0 ? "Amount Paid ($)*" : "Monto Pagado ($)*"}
-              // {...register("amountPaid", {
-              // required: "Amount Paid is required",
-              // pattern: {
-              //   value: /^\$?\d{1,3}(,\d{3})*(\.\d{2})?$/,
-              //   message: "Not in a familiar format.",
-              // },
-              // })}
-            />
-            <div className="w-[350px] mt-[10px] ml-[25px]">
-              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
-            </div>
-            {renderNavButtons(true, false)}
-          </div>
-        );
+        return <div></div>;
       case 5:
-        // NOTE: There may be code below that is not currently used because field is
-        // not required until we have a payment system set up.
-        return (
-          <div>
-            <div className="grid gap-4 mt-[60px] justify-start items-start">
-              <div>
-                <Input
-                  key={`cardName-${step}`}
-                  className="w-[550px] border-[#8C8C8C]"
-                  type="text"
-                  id="CardName"
-                  placeholder={paymentInfoFieldNames[langOption][0]}
-                  // {...register()}
-                />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`billingAddress-${step}`}
-                  className="w-[372px] border-[#8C8C8C]"
-                  type="text"
-                  id="BillingAddress"
-                  placeholder={paymentInfoFieldNames[langOption][1]}
-                  // {...register()}
-                />
-                <Input
-                  key={`billingZIP-${step}`}
-                  className="w-[170px] border-[#8C8C8C]"
-                  type="text"
-                  id="BillingZIP"
-                  placeholder={paymentInfoFieldNames[langOption][2]}
-                  // {...register()}
-                />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`cardNumber-${step}`}
-                  className="w-[372px] border-[#8C8C8C]"
-                  type="text"
-                  id="CardNumber"
-                  placeholder={paymentInfoFieldNames[langOption][3]}
-                  // {...register(, {
-                  //   required: "Card Number is required",
-                  //   pattern: {
-                  //     value: /^(?:\d{4}[-\s]?){3}\d{4}|\d{13,19}$/,
-                  //     message: "Card Number not recognizable digits.",
-                  //   },
-                  //   onChange: (e) => {
-                  //     e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                  //   }
-                  // })}
-                />
-                <Input
-                  key={`cardExpiration-${step}`}
-                  className="w-[81px] border-[#8C8C8C]"
-                  type="text"
-                  id="CardExpiration"
-                  placeholder={paymentInfoFieldNames[langOption][4]}
-                  // {...register(, {
-                  //   pattern: {
-                  //     value: /^(0[1-9]|1[0-2])\/\d{2}$/,
-                  //     message: "Expiration must follow MM/YY format.",
-                  //   },
-                  //   onChange: (e) => {
-                  //     e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                  //   },
-                  // })}
-                />
-                <Input
-                  key={`CVC-${step}`}
-                  className="w-[81px] border-[#8C8C8C]"
-                  type="text"
-                  id="CVC"
-                  placeholder={paymentInfoFieldNames[langOption][5]}
-                  // {...register(, {
-                  //   pattern: {
-                  //     value: /^\d{3}$/,
-                  //     message: "CVC must follow XXX format.",
-                  //   },
-                  //   onChange: (e) => {
-                  //     e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                  //   },
-                  // })}
-                />
-              </div>
-              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
-            </div>
-            {renderNavButtons(true, false)}
-          </div>
-        );
+        return <div></div>;
     }
   };
 

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -43,7 +43,7 @@ const BusinessSignupApplication = () => {
     "Enlaces Sociales",
     "Información del Contacto",
   ];
-  const numPages = 4;
+  const numPages = 5;
   const pageSubtitles = [englishPageSubtitles, spanishPageSubtitles];
 
   // for navigation buttons
@@ -327,7 +327,7 @@ const BusinessSignupApplication = () => {
                 {...register("businessInfo.description", { required: "Description is required" })}
               />
 
-              {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
+              {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
             </div>
 
             {renderNavButtons(false, false)}
@@ -441,7 +441,7 @@ const BusinessSignupApplication = () => {
                   />
                 </div>
               </div>
-              {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
+              {formErrorMessage && <div className="text-red-600 w-full">{formErrorMessage}</div>}
             </div>
 
             {renderNavButtons(true, false)}
@@ -544,7 +544,7 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
             </div>
-            {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
+            {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
             {renderNavButtons(true, true)}
           </div>
         );

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -553,20 +553,20 @@ const BusinessSignupApplication = () => {
 
   if (step < 5) {
     return (
-      <div className="w-[70vw] h-[300px]">
-        <Card className="relative bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] rounded-lg">
-          <CardContent className="flex flex-col md:flex-row w-full h-[320px] mt-[15px] p-1">
-            <div className="w-[35%] flex flex-col items-start text-left p-4">
+      <div className="w-full md:max-w-[70vw] md:h-auto overflow-hidden">
+        <Card className="relative md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
+          <CardContent className="flex flex-col md:flex-row h-full md:h-[320px] mt-[15px] p-1">
+            <div className="w-auto md:w-[35%] flex flex-col items-start text-left p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
               <div className="mt-[40px]">
                 <strong className="text-[24px]">{formTitle[langOption]}</strong>
                 <h4 className="pt-2 text-[16px]">{pageSubtitles[langOption][step - 1]}</h4>
               </div>
             </div>
-            <div className="w-[65%] flex mx-auto">{renderStepForm()}</div>
+            <div className="w-full md:w-[65%] flex mx-auto">{renderStepForm()}</div>
           </CardContent>
         </Card>
-        <div className="flex flex-row justify-start">
+        <div className="hidden md:block md:flex md:flex-row md:justify-start">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -587,9 +587,9 @@ const BusinessSignupApplication = () => {
     );
   } else {
     return (
-      <div className="w-[70vw] h-[300px]">
-        <Card className="relative bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] rounded-lg">
-          <CardContent className="flex flex-col w-full h-[320px] mt-[15px] p-1 items-center">
+      <div className="w-full h-screen md:max-w-[70vw] md:h-auto overflow-hidden">
+        <Card className="relative shadow-none md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
+          <CardContent className="flex flex-col w-full h-[320px] mt-[15px] items-center">
             <div className="w-full flex items-start p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
             </div>
@@ -607,7 +607,7 @@ const BusinessSignupApplication = () => {
             </div>
           </CardContent>
         </Card>
-        <div className="flex flex-row justify-start">
+        <div className="hidden md:block md:flex md:flex-row md:justify-start">
           <DropdownMenu>
             <DropdownMenuTrigger>
               <Button

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -408,7 +408,7 @@ const BusinessSignupApplication = () => {
                       id="sameAddress"
                       onChange={(e) => setIsMailingAddressSame(e.target.checked)}
                     />
-                    {businessInfoFieldNames[langOption][8]}
+                    {businessInfoFieldNames[langOption][7]}
                   </label>
                 </div>
               </div>
@@ -465,74 +465,86 @@ const BusinessSignupApplication = () => {
       case 2:
         return (
           <div>
-            <div className="grid gap-4 mt-[60px] justify-start items-start">
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`contactName-${step}`}
-                  className="w-[356px] border-[#8C8C8C]"
-                  type="text"
-                  id="ContactName"
-                  placeholder={contactInfoFieldNames[langOption][0]}
-                  {...register("contactInfo.name", { required: "Contact Name is required" })}
-                />
-                <Input
-                  key={`contactTitle-${step}`}
-                  className="w-[186px] border-[#8C8C8C]"
-                  type="text"
-                  id="ContactTitle"
-                  placeholder={contactInfoFieldNames[langOption][1]}
-                  {...register("contactInfo.title", { required: "Title is required" })}
-                />
+            <div className="grid gap-4 mt-5">
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-11">
+                  <Input
+                    key={`contactName-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="ContactName"
+                    placeholder={contactInfoFieldNames[langOption][0]}
+                    {...register("contactInfo.name", { required: "Contact Name is required" })}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-11">
+                  <Input
+                    key={`contactTitle-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="ContactTitle"
+                    placeholder={contactInfoFieldNames[langOption][1]}
+                    {...register("contactInfo.title", { required: "Title is required" })}
+                  />
+                </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`contactPhoneNumber-${step}`}
-                  className="w-[271px] border-[#8C8C8C]"
-                  type="text"
-                  id="PhoneNumber"
-                  placeholder={contactInfoFieldNames[langOption][2]}
-                  {...register("contactInfo.phoneNumber", {
-                    required: "Phone Number is required",
-                    pattern: {
-                      value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
-                      message: "Phone Number must have nine digits.",
-                    },
-                    onChange: (e) => {
-                      e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                    },
-                  })}
-                />
-                <Input
-                  key={`contactCellNumber-${step}`}
-                  className="w-[271px] border-[#8C8C8C]"
-                  type="text"
-                  id="CellNumber"
-                  placeholder={contactInfoFieldNames[langOption][3]}
-                  {...register("contactInfo.cellNumber", {
-                    pattern: {
-                      value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
-                      message: "Cell Number must have ten digits.",
-                    },
-                    onChange: (e) => {
-                      e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                    },
-                  })}
-                />
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-5">
+                  <Input
+                    key={`contactPhoneNumber-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="PhoneNumber"
+                    placeholder={contactInfoFieldNames[langOption][2]}
+                    {...register("contactInfo.phoneNumber", {
+                      required: "Phone Number is required",
+                      pattern: {
+                        value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
+                        message: "Phone Number must have nine digits.",
+                      },
+                      onChange: (e) => {
+                        e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
+                      },
+                    })}
+                  />
+                </div>
+                <div className="col-span-5">
+                  <Input
+                    key={`contactCellNumber-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="CellNumber"
+                    placeholder={contactInfoFieldNames[langOption][3]}
+                    {...register("contactInfo.cellNumber", {
+                      pattern: {
+                        value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
+                        message: "Cell Number must have ten digits.",
+                      },
+                      onChange: (e) => {
+                        e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
+                      },
+                    })}
+                  />
+                </div>
               </div>
 
-              <div>
-                <Input
-                  key={`contactEmail-${step}`}
-                  className="w-[550px] border-[#8C8C8C]"
-                  type="text"
-                  id="ContactEmail"
-                  placeholder={contactInfoFieldNames[langOption][4]}
-                  {...register("contactInfo.email", {
-                    required: "Email is required",
-                    pattern: { value: /^[^@]+@[^@]+$/, message: "Not in a familiar format." },
-                  })}
-                />
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-11">
+                  <Input
+                    key={`contactEmail-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="ContactEmail"
+                    placeholder={contactInfoFieldNames[langOption][4]}
+                    {...register("contactInfo.email", {
+                      required: "Email is required",
+                      pattern: { value: /^[^@]+@[^@]+$/, message: "Not in a familiar format." },
+                    })}
+                  />
+                </div>
               </div>
               {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
             </div>

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -356,7 +356,9 @@ const BusinessSignupApplication = () => {
                 {...register("businessInfo.description", { required: "Description is required" })}
               />
 
-              {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
+              {formErrorMessage && (
+                <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+              )}
             </div>
 
             {renderNavButtons(false, false)}
@@ -470,7 +472,9 @@ const BusinessSignupApplication = () => {
                   </div>
                 </div>
               )}
-              {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
+              {formErrorMessage && (
+                <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+              )}
             </div>
 
             {renderNavButtons(true, false)}
@@ -573,7 +577,9 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
             </div>
-            {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
+            {formErrorMessage && (
+              <div className="text-red-600 w-full md:pr-16 text-center md:text-start">{formErrorMessage}</div>
+            )}
             {renderNavButtons(true, true)}
           </div>
         );
@@ -597,7 +603,7 @@ const BusinessSignupApplication = () => {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    className="bg-[#293241] text-white hover:text-blue-500 hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
+                    className="bg-[#405BA9] text-white hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
                     type="button"
                   >
                     {langOptions[langOption]}
@@ -655,7 +661,7 @@ const BusinessSignupApplication = () => {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    className="bg-[#293241] text-white hover:text-blue-500 hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
+                    className="bg-[#405BA9] text-white hover:bg-[#293241] hover:opacity-100 hover:shadow-none"
                     type="button"
                   >
                     {langOptions[langOption]}

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -117,6 +117,8 @@ const BusinessSignupApplication = () => {
   const submissionSteps = [submissionEnglishSteps, submissionSpanishSteps];
 
   const [step, setStep] = useState(1);
+  const [password1, setPassword1] = useState("");
+  const [password2, setPassword2] = useState("");
   const {
     register,
     formState: { errors },
@@ -136,11 +138,11 @@ const BusinessSignupApplication = () => {
     },
   });
 
-  const [firstErrorMessage, setFirstErrorMessage] = useState("");
+  const [formErrorMessage, setFormErrorMessage] = useState("");
   const changeLanguage = (val: number) => {
     setLangOption(val);
-    if (firstErrorMessage !== "") {
-      setFirstErrorMessage(errorMsgs[val]);
+    if (errorMsgs[0].includes(formErrorMessage) || errorMsgs[1].includes(formErrorMessage)) {
+      setFormErrorMessage(errorMsgs[val]);
     }
   };
 
@@ -153,15 +155,15 @@ const BusinessSignupApplication = () => {
     trigger()
       .then((result) => {
         if (!result) {
-          setFirstErrorMessage(errorMsgs[langOption]);
+          setFormErrorMessage(errorMsgs[langOption]);
         } else {
-          setFirstErrorMessage("");
+          setFormErrorMessage("");
           setStep(Math.min(numPages, step + 1));
         }
       })
       .catch((error) => {
         console.error("Validation error:", error);
-        setFirstErrorMessage("An unexpected error occurred during validation.");
+        setFormErrorMessage("An unexpected error occurred during validation.");
       });
   };
 
@@ -214,7 +216,7 @@ const BusinessSignupApplication = () => {
     }
   };
   const prevStep = () => {
-    setFirstErrorMessage("");
+    setFormErrorMessage("");
     setStep(Math.max(1, step - 1));
   };
 
@@ -325,7 +327,7 @@ const BusinessSignupApplication = () => {
                 {...register("businessInfo.description", { required: "Description is required" })}
               />
 
-              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
+              {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
             </div>
 
             {renderNavButtons(false, false)}
@@ -439,7 +441,7 @@ const BusinessSignupApplication = () => {
                   />
                 </div>
               </div>
-              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
+              {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
             </div>
 
             {renderNavButtons(true, false)}
@@ -476,73 +478,74 @@ const BusinessSignupApplication = () => {
         );
       case 4:
         return (
-          <div>
+          <div className="w-[90%] mr-auto ml-auto">
             <div className="grid gap-4 mt-5">
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-12">
-                  <Input
-                    key={`contactName-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="ContactName"
-                    placeholder={contactInfoFieldNames[langOption][0]}
-                    {...register("contactInfo.name", { required: "Contact Name is required" })}
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-12">
-                  <Input
-                    key={`contactTitle-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="ContactTitle"
-                    placeholder={contactInfoFieldNames[langOption][1]}
-                    {...register("contactInfo.name", { required: "Title is required" })}
-                  />
-                </div>
-              </div>
+              <Input
+                key={`contactName-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="ContactName"
+                placeholder={contactInfoFieldNames[langOption][0]}
+                {...register("contactInfo.name", { required: "Contact Name is required" })}
+              />
+
+              <Input
+                key={`contactPhone-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="Phone"
+                placeholder={contactInfoFieldNames[langOption][1]}
+                {...register("contactInfo.phone", {
+                  required: "Phone Number is required",
+                  pattern: {
+                    value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
+                    message: "Phone Number must have nine digits.",
+                  },
+                  onChange: (e) => {
+                    e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
+                  },
+                })}
+              />
+
+              <Input
+                key={`contactEmail-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="ContactEmail"
+                placeholder={contactInfoFieldNames[langOption][2]}
+                {...register("contactInfo.email", {
+                  required: "Email is required",
+                  pattern: { value: /^[^@]+@[^@]+$/, message: "Not in a familiar format." },
+                })}
+              />
 
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-5">
+                <div className="col-span-6">
                   <Input
-                    key={`contactPhoneNumber-${step}`}
+                    key={`password1-${step}`}
                     className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="PhoneNumber"
-                    placeholder={contactInfoFieldNames[langOption][2]}
-                    {...register("contactInfo.phone", {
-                      required: "Phone Number is required",
-                      pattern: {
-                        value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
-                        message: "Phone Number must have nine digits.",
-                      },
-                      onChange: (e) => {
-                        e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                      },
-                    })}
+                    type="password"
+                    id="Password1"
+                    value={password1}
+                    placeholder={contactInfoFieldNames[langOption][3]}
+                    onChange={(e) => setPassword1(e.target.value)}
                   />
                 </div>
-              </div>
-
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-12">
+                <div className="col-span-6">
                   <Input
-                    key={`contactEmail-${step}`}
+                    key={`password2-${step}`}
                     className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="ContactEmail"
+                    type="password"
+                    id="Password2"
+                    value={password2}
                     placeholder={contactInfoFieldNames[langOption][4]}
-                    {...register("contactInfo.email", {
-                      required: "Email is required",
-                      pattern: { value: /^[^@]+@[^@]+$/, message: "Not in a familiar format." },
-                    })}
+                    onChange={(e) => setPassword2(e.target.value)}
                   />
                 </div>
               </div>
-              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
             </div>
-            {renderNavButtons(true, false)}
+            {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
+            {renderNavButtons(true, true)}
           </div>
         );
     }

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -224,7 +224,7 @@ const BusinessSignupApplication = () => {
     setStep(Math.max(1, step - 1));
   };
 
-  const handleSameMailingAddressCheckbox = (e) => {
+  const handleSameMailingAddressCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
     const checked = e.target.checked;
     setFormErrorMessage("");
     if (!checked) {

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -336,7 +336,7 @@ const BusinessSignupApplication = () => {
           <div className="w-[90%] mt-[8%] mr-auto ml-auto">
             <div className="grid gap-4 mt-5">
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-4">
+                <div className="col-span-5">
                   <Input
                     key={`physicalAddress-Addr-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -395,7 +395,7 @@ const BusinessSignupApplication = () => {
               </div>
 
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-4">
+                <div className="col-span-5">
                   <Input
                     key={`mailingAddress-Addr-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -432,13 +432,45 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="MailAddress-ZIP"
                     placeholder={businessInfoFieldNames[langOption][9]}
-                    {...register("businessInfo.mailingAddress.zip", { required: "ZIP is required" })}
+                    {...register("businessInfo.mailingAddress.zip", {
+                      required: "ZIP is required",
+                      pattern: { value: /^\d{5}$/, message: "ZIP code must be exactly 5 digits" },
+                    })}
                   />
                 </div>
               </div>
               {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
             </div>
 
+            {renderNavButtons(true, false)}
+          </div>
+        );
+      case 3:
+        return (
+          <div className="w-[90%] mt-[8%] mr-auto ml-auto">
+            <div className="grid gap-4 mt-5">
+              <Input
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="Facebook"
+                placeholder="Facebook"
+                {...register("socialLinks.FB", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
+              />
+              <Input
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="Instagram"
+                placeholder="Instagram"
+                {...register("socialLinks.IG", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
+              />
+              <Input
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="X"
+                placeholder="X"
+                {...register("socialLinks.X", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
+              />
+            </div>
             {renderNavButtons(true, false)}
           </div>
         );
@@ -513,45 +545,6 @@ const BusinessSignupApplication = () => {
             {renderNavButtons(true, false)}
           </div>
         );
-      case 3:
-        return (
-          <div>
-            <div className="grid grid-cols-2 gap-6 mt-[80px] justify-start">
-              <div>
-                <Input
-                  className="w-[250px] border-[#8C8C8C]"
-                  type="text"
-                  id="Facebook"
-                  placeholder="Facebook"
-                  {...register("socialLinks.FB", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
-                />
-              </div>
-              <div>
-                <Input
-                  className="w-[250px] border-[#8C8C8C]"
-                  type="text"
-                  id="Instagram"
-                  placeholder="Instagram"
-                  {...register("socialLinks.IG", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
-                />
-              </div>
-              <div>
-                <Input
-                  className="w-[250px] border-[#8C8C8C]"
-                  type="text"
-                  id="X"
-                  placeholder="X"
-                  {...register("socialLinks.X", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
-                />
-              </div>
-            </div>
-            {renderNavButtons(true, false)}
-          </div>
-        );
-      case 4:
-        return <div></div>;
-      case 5:
-        return <div></div>;
     }
   };
 

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -141,7 +141,11 @@ const BusinessSignupApplication = () => {
   const [formErrorMessage, setFormErrorMessage] = useState("");
   const changeLanguage = (val: number) => {
     setLangOption(val);
-    if (errorMsgs[0].includes(formErrorMessage) || errorMsgs[1].includes(formErrorMessage)) {
+    console.log(`formErrorMessage: ${formErrorMessage}`);
+    if (
+      formErrorMessage !== "" &&
+      (errorMsgs[0].includes(formErrorMessage) || errorMsgs[1].includes(formErrorMessage))
+    ) {
       setFormErrorMessage(errorMsgs[val]);
     }
   };
@@ -230,7 +234,12 @@ const BusinessSignupApplication = () => {
       return (
         <div className="absolute bottom-0 left-0 right-0 p-4 flex flex-row items-end justify-between">
           <Button
-            className="bg-white text-[#405BA9] border border-[#405BA9] rounded-3xl"
+            variant="outline"
+            className="
+              text-[#405BA9] border-[#405BA9] rounded-3xl
+              focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:outline-none
+              hover:bg-gray-100
+            "
             type="button"
             onClick={prevStep}
           >
@@ -257,7 +266,12 @@ const BusinessSignupApplication = () => {
       return (
         <div className="absolute bottom-0 left-0 right-0 p-4 flex flex-row items-end justify-between">
           <Button
-            className="bg-white text-[#405BA9] border border-[#405BA9] rounded-3xl"
+            variant="outline"
+            className="
+              text-[#405BA9] border-[#405BA9] rounded-3xl
+              focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:outline-none
+              hover:bg-gray-100
+            "
             type="button"
             onClick={prevStep}
           >
@@ -431,7 +445,7 @@ const BusinessSignupApplication = () => {
                   />
                 </div>
               </div>
-              {formErrorMessage && <div className="text-red-600 w-full">{formErrorMessage}</div>}
+              {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
             </div>
 
             {renderNavButtons(true, false)}

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -559,8 +559,8 @@ const BusinessSignupApplication = () => {
     return (
       <div className="w-full md:max-w-[70vw] md:h-auto">
         <Card className="relative md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] min-h-screen md:min-h-full rounded-none md:rounded-lg">
-          <CardContent className="flex flex-col md:flex-row h-full md:h-[320px] mt-[15px] p-1">
-            <div className="w-auto md:w-[35%] flex flex-col items-start text-left p-4">
+          <CardContent className="flex flex-col md:flex-row justify-center md:justify-start items-center md:items-start h-full md:h-[320px] mt-[15px] p-1">
+            <div className="w-auto md:w-[35%] flex flex-col justify-center items-center text-center p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
               <div className="mt-[40px]">
                 <strong className="text-[24px]">{formTitle[langOption]}</strong>
@@ -611,7 +611,7 @@ const BusinessSignupApplication = () => {
       <div className="w-full md:max-w-[70vw] md:h-auto">
         <Card className="relative shadow-none md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] min-h-screen md:min-h-full rounded-none md:rounded-lg">
           <CardContent className="md:flex-row h-full md:h-[320px] mt-[15px] items-center p-4">
-            <div className="w-full flex items-start p-4">
+            <div className="w-full flex justify-center md:justify-start items-center md:items-start p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
             </div>
             <div className="flex flex-col justify-center items-center w-full h-[60%]">
@@ -626,7 +626,7 @@ const BusinessSignupApplication = () => {
                 </ol>
               </div>
             </div>
-            <div className="md:hidden flex mx-auto justify-center">
+            <div className="md:hidden flex mx-auto justify-center mt-5">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -224,6 +224,21 @@ const BusinessSignupApplication = () => {
     setStep(Math.max(1, step - 1));
   };
 
+  const handleSameMailingAddressCheckbox = (e) => {
+    const checked = e.target.checked;
+    setFormErrorMessage("");
+    if (!checked) {
+      if (isMailingAddressSame) {
+        // flush out mailing address info if checkbox is unchecked
+        setValue("businessInfo.mailingAddress.street", "");
+        setValue("businessInfo.mailingAddress.city", "");
+        setValue("businessInfo.mailingAddress.state", "");
+        setValue("businessInfo.mailingAddress.zip", "");
+      }
+    }
+    setIsMailingAddressSame(checked);
+  };
+
   // handle business addresses
   const [isMailingAddressSame, setIsMailingAddressSame] = useState(false);
 
@@ -349,7 +364,7 @@ const BusinessSignupApplication = () => {
         );
       case 2:
         return (
-          <div className="w-[90%] mr-auto ml-auto">
+          <div className="w-[90%] mr-auto ml-auto mt-[-10px]">
             <div className="grid gap-4 mt-5">
               <Input
                 key={`physicalAddress-Addr-${step}`}
@@ -395,56 +410,66 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
 
-              <div className="flex items-center mt-[-8px] mb-[-8px] text-[13px]">
+              <div className="flex items-center mt-[-8px] mb-[-25px] text-[13px]">
                 <label htmlFor="sameAddress" className="flex items-center">
-                  <input type="checkbox" id="sameAddress" onChange={(e) => setIsMailingAddressSame(e.target.checked)} />
+                  <input
+                    type="checkbox"
+                    className="mr-[4px]"
+                    id="sameAddress"
+                    checked={isMailingAddressSame}
+                    onChange={handleSameMailingAddressCheckbox}
+                  />
                   {businessInfoFieldNames[langOption][10]}
                 </label>
               </div>
 
-              <Input
-                key={`mailingAddress-Addr-${step}`}
-                className="w-full border-[#8C8C8C]"
-                type="text"
-                id="MailAddress-Addr"
-                placeholder={businessInfoFieldNames[langOption][6]}
-                {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
-              />
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-5">
+              {!isMailingAddressSame && (
+                <div className="grid gap-4 mt-5">
                   <Input
-                    key={`mailingAddress-City-${step}`}
+                    key={`mailingAddress-Addr-${step}`}
                     className="w-full border-[#8C8C8C]"
                     type="text"
-                    id="MailAddress-City"
-                    placeholder={businessInfoFieldNames[langOption][7]}
-                    {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
+                    id="MailAddress-Addr"
+                    placeholder={businessInfoFieldNames[langOption][6]}
+                    {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
                   />
+                  <div className="grid grid-cols-12 gap-2">
+                    <div className="col-span-5">
+                      <Input
+                        key={`mailingAddress-City-${step}`}
+                        className="w-full border-[#8C8C8C]"
+                        type="text"
+                        id="MailAddress-City"
+                        placeholder={businessInfoFieldNames[langOption][7]}
+                        {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
+                      />
+                    </div>
+                    <div className="col-span-4">
+                      <Input
+                        key={`mailingAddress-State-${step}`}
+                        className="w-full border-[#8C8C8C]"
+                        type="text"
+                        id="MailAddress-State"
+                        placeholder={businessInfoFieldNames[langOption][8]}
+                        {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
+                      />
+                    </div>
+                    <div className="col-span-3">
+                      <Input
+                        key={`mailingAddress-ZIP-${step}`}
+                        className="w-full border-[#8C8C8C]"
+                        type="text"
+                        id="MailAddress-ZIP"
+                        placeholder={businessInfoFieldNames[langOption][9]}
+                        {...register("businessInfo.mailingAddress.zip", {
+                          required: "ZIP is required",
+                          pattern: { value: /^\d{5}$/, message: "ZIP code must be exactly 5 digits" },
+                        })}
+                      />
+                    </div>
+                  </div>
                 </div>
-                <div className="col-span-4">
-                  <Input
-                    key={`mailingAddress-State-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="MailAddress-State"
-                    placeholder={businessInfoFieldNames[langOption][8]}
-                    {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
-                  />
-                </div>
-                <div className="col-span-3">
-                  <Input
-                    key={`mailingAddress-ZIP-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="MailAddress-ZIP"
-                    placeholder={businessInfoFieldNames[langOption][9]}
-                    {...register("businessInfo.mailingAddress.zip", {
-                      required: "ZIP is required",
-                      pattern: { value: /^\d{5}$/, message: "ZIP code must be exactly 5 digits" },
-                    })}
-                  />
-                </div>
-              </div>
+              )}
               {formErrorMessage && <div className="text-red-600 w-full pr-16">{formErrorMessage}</div>}
             </div>
 

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -11,35 +11,17 @@ import { Button } from "./button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./dropdown-menu";
 
 interface BusinessSignupAppInfo {
-  contactInfo: {
-    name: string;
-    phone: string;
-    email: string;
-  };
+  contactInfo: { name: string; phone: string; email: string };
   businessInfo: {
     businessName: string;
     website: string;
     businessOwner: string;
     businessType: string;
     description: string;
-    physicalAddress: {
-      street: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
-    mailingAddress: {
-      street: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
+    physicalAddress: { street: string; city: string; state: string; zip: string };
+    mailingAddress: { street: string; city: string; state: string; zip: string };
   };
-  socialLinks: {
-    IG?: string;
-    X?: string;
-    FB?: string;
-  };
+  socialLinks: { IG?: string; X?: string; FB?: string };
 }
 
 const BusinessSignupApplication = () => {
@@ -54,23 +36,14 @@ const BusinessSignupApplication = () => {
   const formTitle = ["Membership Application", "Solicitud de Membresía"];
 
   // page subtitles by language
-  const englishPageSubtitles = [
-    "Business Information",
-    "Business Information",
-    "Social Links",
-    "Payment Information",
-    "Payment Method",
-    "Contact Information",
-  ];
+  const englishPageSubtitles = ["Business Information", "Business Information", "Social Links", "Contact Information"];
   const spanishPageSubtitles = [
     "Información Comercial",
     "Información Comercial",
     "Enlaces Sociales",
-    "Información de Pago",
-    "Método de Pago",
     "Información del Contacto",
   ];
-  const numPages = 7;
+  const numPages = 4;
   const pageSubtitles = [englishPageSubtitles, spanishPageSubtitles];
 
   // for navigation buttons
@@ -229,18 +202,15 @@ const BusinessSignupApplication = () => {
         }
         validateData();
         break;
-      case 2: // contact information page
+      case 2: // address information
         validateData();
         break;
       case 3: // social links page
         setStep(Math.min(numPages, step + 1));
         break;
-      case 4: // payment information page
+      case 4: // contact information page
         validateData();
         break;
-      case 5: // payment method page
-        gatherAllData();
-        setStep(Math.min(numPages, step + 1));
     }
   };
   const prevStep = () => {
@@ -303,92 +273,68 @@ const BusinessSignupApplication = () => {
     switch (step) {
       case 1:
         return (
-          // <div>
-          //   <div className="grid gap-4 mt-[20px] justify-start items-start">
-          //     <div>
-          //       <Input
-          //         key={`businessName-${step}`}
-          //         className="w-[550px] border-[#8C8C8C]"
-          //         type="text"
-          //         id="BusinessName"
-          //         placeholder={businessInfoFieldNames[langOption][0]}
-          //         {...register("businessInfo.businessName", { required: "Business name is required" })}
-          //       />
-          //     </div>
+          <div className="w-[90%] mr-auto ml-auto">
+            <div className="grid gap-4 mt-5">
+              <Input
+                key={`businessName-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="BusinessName"
+                placeholder={businessInfoFieldNames[langOption][0]}
+                {...register("businessInfo.businessName", { required: "Business name is required" })}
+              />
 
-          //     <div>
-          //       <Input
-          //         key={`websiteURL-${step}`}
-          //         className="w-[550px] border-[#8C8C8C]"
-          //         type="text"
-          //         id="WebsiteURL"
-          //         placeholder={businessInfoFieldNames[langOption][1]}
-          //         {...register("businessInfo.website", { required: "Website URL is required" })}
-          //       />
-          //     </div>
+              <Input
+                key={`websiteURL-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="WebsiteURL"
+                placeholder={businessInfoFieldNames[langOption][1]}
+                {...register("businessInfo.website", { required: "Website URL is required" })}
+              />
 
-          //     <div className="flex items-center gap-2">
-          //       <Input
-          //         key={`businessType-${step}`}
-          //         className="w-[275px] border-[#8C8C8C]"
-          //         type="text"
-          //         id="businessType"
-          //         placeholder={businessInfoFieldNames[langOption][2]}
-          //         {...register("businessInfo.businessType", { required: "Business Type is required" })}
-          //       />
-          //       <Input
-          //         key={`businessOwner-${step}`}
-          //         className="w-[275px] border-[#8C8C8C]"
-          //         type="text"
-          //         id="businessOwner"
-          //         placeholder={businessInfoFieldNames[langOption][3]}
-          //         {...register("businessInfo.businessOwner", { required: "Business Owner is required" })}
-          //       />
-          //     </div>
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-6">
+                  <Input
+                    key={`businessType-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="businessType"
+                    placeholder={businessInfoFieldNames[langOption][2]}
+                    {...register("businessInfo.businessType", { required: "Business Type is required" })}
+                  />
+                </div>
+                <div className="col-span-6">
+                  <Input
+                    key={`businessOwner-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="businessOwner"
+                    placeholder={businessInfoFieldNames[langOption][3]}
+                    {...register("businessInfo.businessOwner", { required: "Business Owner is required" })}
+                  />
+                </div>
+              </div>
 
-          //     <div>
-          //       <Input
-          //         key={`description-${step}`}
-          //         className="w-[550px] border-[#8C8C8C]"
-          //         type="text"
-          //         id="description"
-          //         placeholder={businessInfoFieldNames[langOption][4]}
-          //         {...register("businessInfo.description", { required: "Description is required" })}
-          //       />
-          //     </div>
-          //     {formErrorMessage && <div className="text-red-600">{formErrorMessage}</div>}
-          //   </div>
-          //   {renderNavButtons(false, false)}
-          // </div>
+              <Input
+                key={`description-${step}`}
+                className="w-full border-[#8C8C8C]"
+                type="text"
+                id="description"
+                placeholder={businessInfoFieldNames[langOption][4]}
+                {...register("businessInfo.description", { required: "Description is required" })}
+              />
 
+              {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
+            </div>
+
+            {renderNavButtons(false, false)}
+          </div>
+        );
+      case 2:
+        return (
           <div>
             <div className="grid gap-4 mt-5">
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-11">
-                  <Input
-                    key={`businessName-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="BusinessName"
-                    placeholder={businessInfoFieldNames[langOption][0]}
-                    {...register("businessInfo.businessName", { required: "Business name is required" })}
-                  />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-11">
-                  <Input
-                    key={`websiteURL-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="WebsiteURL"
-                    placeholder={businessInfoFieldNames[langOption][1]}
-                    {...register("businessInfo.website", { required: "Website URL is required" })}
-                  />
-                </div>
-              </div>
-
               <div className="grid grid-cols-12 gap-2">
                 <div className="col-span-4">
                   <Input
@@ -490,19 +436,18 @@ const BusinessSignupApplication = () => {
                   />
                 </div>
               </div>
-
               {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
             </div>
 
-            {renderNavButtons(false, false)}
+            {renderNavButtons(true, false)}
           </div>
         );
-      case 2:
+      case 4:
         return (
           <div>
             <div className="grid gap-4 mt-5">
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-11">
+                <div className="col-span-12">
                   <Input
                     key={`contactName-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -514,7 +459,7 @@ const BusinessSignupApplication = () => {
                 </div>
               </div>
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-11">
+                <div className="col-span-12">
                   <Input
                     key={`contactTitle-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -549,7 +494,7 @@ const BusinessSignupApplication = () => {
               </div>
 
               <div className="grid grid-cols-12 gap-2">
-                <div className="col-span-11">
+                <div className="col-span-12">
                   <Input
                     key={`contactEmail-${step}`}
                     className="w-full border-[#8C8C8C]"
@@ -578,9 +523,7 @@ const BusinessSignupApplication = () => {
                   type="text"
                   id="Facebook"
                   placeholder="Facebook"
-                  {...register("socialLinks.FB", {
-                    pattern: { value: /^@/, message: "Not in a familiar format." },
-                  })}
+                  {...register("socialLinks.FB", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
                 />
               </div>
               <div>
@@ -589,9 +532,7 @@ const BusinessSignupApplication = () => {
                   type="text"
                   id="Instagram"
                   placeholder="Instagram"
-                  {...register("socialLinks.IG", {
-                    pattern: { value: /^@/, message: "Not in a familiar format." },
-                  })}
+                  {...register("socialLinks.IG", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
                 />
               </div>
               <div>
@@ -614,7 +555,7 @@ const BusinessSignupApplication = () => {
     }
   };
 
-  if (step < 6) {
+  if (step < 4) {
     return (
       <div className="w-[70vw] h-[300px]">
         <Card className="relative bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] rounded-lg">
@@ -626,7 +567,7 @@ const BusinessSignupApplication = () => {
                 <h4 className="pt-2 text-[16px]">{pageSubtitles[langOption][step - 1]}</h4>
               </div>
             </div>
-            <div className="w-[65%] flex justify-center mx-auto">{renderStepForm()}</div>
+            <div className="w-[65%] flex mx-auto">{renderStepForm()}</div>
           </CardContent>
         </Card>
         <div className="flex flex-row justify-start">

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -371,7 +371,7 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="BusinessName"
                     placeholder={businessInfoFieldNames[langOption][0]}
-                    {...register("businessInfo.name", { required: "Business name is required" })}
+                    {...register("businessInfo.businessName", { required: "Business name is required" })}
                   />
                 </div>
               </div>
@@ -384,7 +384,7 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="WebsiteURL"
                     placeholder={businessInfoFieldNames[langOption][1]}
-                    {...register("businessInfo.websiteURL", { required: "Website URL is required" })}
+                    {...register("businessInfo.website", { required: "Website URL is required" })}
                   />
                 </div>
               </div>
@@ -397,7 +397,7 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="PhysicalAddress-Addr"
                     placeholder={businessInfoFieldNames[langOption][2]}
-                    {...register("businessInfo.physicalAddress.address", { required: "Address is required" })}
+                    {...register("businessInfo.physicalAddress.street", { required: "Address is required" })}
                   />
                 </div>
                 <div className="col-span-3">
@@ -456,7 +456,7 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="MailAddress-Addr"
                     placeholder={businessInfoFieldNames[langOption][3]}
-                    {...register("businessInfo.mailingAddress.address", { required: "Address is required" })}
+                    {...register("businessInfo.mailingAddress.street", { required: "Address is required" })}
                   />
                 </div>
                 <div className="col-span-3">
@@ -521,7 +521,7 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="ContactTitle"
                     placeholder={contactInfoFieldNames[langOption][1]}
-                    {...register("contactInfo.title", { required: "Title is required" })}
+                    {...register("contactInfo.name", { required: "Title is required" })}
                   />
                 </div>
               </div>
@@ -534,29 +534,11 @@ const BusinessSignupApplication = () => {
                     type="text"
                     id="PhoneNumber"
                     placeholder={contactInfoFieldNames[langOption][2]}
-                    {...register("contactInfo.phoneNumber", {
+                    {...register("contactInfo.phone", {
                       required: "Phone Number is required",
                       pattern: {
                         value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
                         message: "Phone Number must have nine digits.",
-                      },
-                      onChange: (e) => {
-                        e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
-                      },
-                    })}
-                  />
-                </div>
-                <div className="col-span-5">
-                  <Input
-                    key={`contactCellNumber-${step}`}
-                    className="w-full border-[#8C8C8C]"
-                    type="text"
-                    id="CellNumber"
-                    placeholder={contactInfoFieldNames[langOption][3]}
-                    {...register("contactInfo.cellNumber", {
-                      pattern: {
-                        value: /^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/,
-                        message: "Cell Number must have ten digits.",
                       },
                       onChange: (e) => {
                         e.target.value = e.target.value.replace(/\D/g, ""); // Remove non-numeric characters
@@ -596,7 +578,7 @@ const BusinessSignupApplication = () => {
                   type="text"
                   id="Facebook"
                   placeholder="Facebook"
-                  {...register("socialLinks.Facebook", {
+                  {...register("socialLinks.FB", {
                     pattern: { value: /^@/, message: "Not in a familiar format." },
                   })}
                 />
@@ -607,7 +589,7 @@ const BusinessSignupApplication = () => {
                   type="text"
                   id="Instagram"
                   placeholder="Instagram"
-                  {...register("socialLinks.Instagram", {
+                  {...register("socialLinks.IG", {
                     pattern: { value: /^@/, message: "Not in a familiar format." },
                   })}
                 />
@@ -643,7 +625,6 @@ const BusinessSignupApplication = () => {
                 <strong className="text-[24px]">{formTitle[langOption]}</strong>
                 <h4 className="pt-2 text-[16px]">{pageSubtitles[langOption][step - 1]}</h4>
               </div>
-              {displayPaymentInfo()}
             </div>
             <div className="w-[65%] flex justify-center mx-auto">{renderStepForm()}</div>
           </CardContent>
@@ -660,8 +641,6 @@ const BusinessSignupApplication = () => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-              {/* <DropdownMenuItem onClick={() => setLangOption(0)}>{langOptions[0]}</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setLangOption(1)}>{langOptions[1]}</DropdownMenuItem> */}
               <DropdownMenuItem onClick={() => changeLanguage(0)}>{langOptions[0]}</DropdownMenuItem>
               <DropdownMenuItem onClick={() => changeLanguage(1)}>{langOptions[1]}</DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -11,36 +11,15 @@ import { Button } from "./button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./dropdown-menu";
 
 interface BusinessSignupAppInfo {
-  contactInfo: {
-    name: string;
-    title: string;
-    phoneNumber?: string;
-    cellNumber?: string;
-    email: string;
-  };
+  contactInfo: { name: string; title: string; phoneNumber?: string; cellNumber?: string; email: string };
   businessInfo: {
     name: string;
     websiteURL?: string;
     numEmployees?: string;
-    physicalAddress: {
-      address: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
-    mailingAddress: {
-      address: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
+    physicalAddress: { address: string; city: string; state: string; zip: string };
+    mailingAddress: { address: string; city: string; state: string; zip: string };
   };
-  socialLinks: {
-    Instagram?: string;
-    X?: string;
-    Facebook?: string;
-    LinkedIn?: string;
-  };
+  socialLinks: { Instagram?: string; X?: string; Facebook?: string; LinkedIn?: string };
 }
 
 const BusinessSignupApplication = () => {
@@ -82,7 +61,6 @@ const BusinessSignupApplication = () => {
   const englishBusinessInfo = [
     "Business Name*",
     "Website URL*",
-    "Number of Employees",
     "Physical Address*",
     "Mailing Address*",
     "City*",
@@ -93,7 +71,6 @@ const BusinessSignupApplication = () => {
   const spanishBusinessInfo = [
     "Nombre Comercial*",
     "URL del Sitio Web*",
-    "Numero de Empleados",
     "Dirección Física*",
     "Dirección de Envio",
     "Ciudad*",
@@ -163,7 +140,6 @@ const BusinessSignupApplication = () => {
       businessInfo: {
         name: "",
         websiteURL: "",
-        numEmployees: "",
         physicalAddress: { address: "", city: "", state: "", zip: "" },
         mailingAddress: { address: "", city: "", state: "", zip: "" },
       },
@@ -351,127 +327,138 @@ const BusinessSignupApplication = () => {
       case 1:
         return (
           <div>
-            <div className="grid gap-4 mt-[20px] justify-start items-start">
-              <div>
-                <Input
-                  key={`businessName-${step}`}
-                  className="w-[550px] border-[#8C8C8C]"
-                  type="text"
-                  id="BusinessName"
-                  placeholder={businessInfoFieldNames[langOption][0]}
-                  {...register("businessInfo.name", { required: "Business name is required" })}
-                />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`websiteURL-${step}`}
-                  className="w-[356px] border-[#8C8C8C]"
-                  type="text"
-                  id="WebsiteURL"
-                  placeholder={businessInfoFieldNames[langOption][1]}
-                  {...register("businessInfo.websiteURL", { required: "Website URL is required" })}
-                />
-                <Input
-                  key={`numEmployees-${step}`}
-                  className="w-[186px] border-[#8C8C8C]"
-                  type="text"
-                  id="NumEmployees"
-                  placeholder={businessInfoFieldNames[langOption][2]}
-                  {...register("businessInfo.numEmployees", {
-                    validate: (value) => value === "" || Number(value) >= 0 || "Number of employees cannot be negative",
-                  })}
-                />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`physicalAddress-Addr-${step}`}
-                  className="w-[264px] border-[#8C8C8C]"
-                  type="text"
-                  id="PhysicalAddress-Addr"
-                  placeholder={businessInfoFieldNames[langOption][3]}
-                  {...register("businessInfo.physicalAddress.address", { required: "Address is required" })}
-                />
-                <Input
-                  key={`physicalAddress-City-${step}`}
-                  className="w-[130px] border-[#8C8C8C]"
-                  type="text"
-                  id="PhysicalAddress-City"
-                  placeholder={businessInfoFieldNames[langOption][5]}
-                  {...register("businessInfo.physicalAddress.city", { required: "City is required" })}
-                />
-                <Input
-                  key={`physicalAddress-State-${step}`}
-                  className="w-[72px] border-[#8C8C8C]"
-                  type="text"
-                  id="PhysicalAddress-State"
-                  placeholder={businessInfoFieldNames[langOption][6]}
-                  {...register("businessInfo.physicalAddress.state", { required: "State is required" })}
-                />
-                <Input
-                  key={`physicalAddress-ZIP-${step}`}
-                  className="w-[60px] border-[#8C8C8C]"
-                  type="text"
-                  id="PhysicalAddress-ZIP"
-                  placeholder={businessInfoFieldNames[langOption][7]}
-                  {...register("businessInfo.physicalAddress.zip", {
-                    required: "ZIP is required",
-                    pattern: {
-                      value: /^\d{5}$/, // Ensures exactly 5 digits
-                      message: "ZIP code must be exactly 5 digits",
-                    },
-                  })}
-                />
-              </div>
-
-              <div className="flex items-center mt-[-8px] mb-[-8px] text-[13px]">
-                <label htmlFor="sameAddress" className="flex items-center">
-                  <input
-                    type="checkbox"
-                    id="sameAddress"
-                    onChange={(e) => setIsMailingAddressSame(e.target.checked)} // use state to track if the checkbox is checked
+            <div className="grid gap-4 mt-5">
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-11">
+                  <Input
+                    key={`businessName-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="BusinessName"
+                    placeholder={businessInfoFieldNames[langOption][0]}
+                    {...register("businessInfo.name", { required: "Business name is required" })}
                   />
-                  {businessInfoFieldNames[langOption][8]}
-                </label>
+                </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                <Input
-                  key={`mailingAddress-Addr-${step}`}
-                  className="w-[264px] border-[#8C8C8C]"
-                  type="text"
-                  id="MailAddress-Addr"
-                  placeholder={businessInfoFieldNames[langOption][4]}
-                  {...register("businessInfo.mailingAddress.address", { required: "Address is required" })}
-                />
-                <Input
-                  key={`mailingAddress-City-${step}`}
-                  className="w-[130px] border-[#8C8C8C]"
-                  type="text"
-                  id="MailAddress-City"
-                  placeholder={businessInfoFieldNames[langOption][5]}
-                  {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
-                />
-                <Input
-                  key={`mailingAddress-State-${step}`}
-                  className="w-[72px] border-[#8C8C8C]"
-                  type="text"
-                  id="MailAddress-State"
-                  placeholder={businessInfoFieldNames[langOption][6]}
-                  {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
-                />
-                <Input
-                  key={`mailingAddress-ZIP-${step}`}
-                  className="w-[60px] border-[#8C8C8C]"
-                  type="text"
-                  id="MailAddress-ZIP"
-                  placeholder={businessInfoFieldNames[langOption][7]}
-                  {...register("businessInfo.mailingAddress.zip", { required: "ZIP is required" })}
-                />
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-11">
+                  <Input
+                    key={`websiteURL-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="WebsiteURL"
+                    placeholder={businessInfoFieldNames[langOption][1]}
+                    {...register("businessInfo.websiteURL", { required: "Website URL is required" })}
+                  />
+                </div>
               </div>
+
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-4">
+                  <Input
+                    key={`physicalAddress-Addr-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="PhysicalAddress-Addr"
+                    placeholder={businessInfoFieldNames[langOption][2]}
+                    {...register("businessInfo.physicalAddress.address", { required: "Address is required" })}
+                  />
+                </div>
+                <div className="col-span-3">
+                  <Input
+                    key={`physicalAddress-City-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="PhysicalAddress-City"
+                    placeholder={businessInfoFieldNames[langOption][4]}
+                    {...register("businessInfo.physicalAddress.city", { required: "City is required" })}
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    key={`physicalAddress-State-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="PhysicalAddress-State"
+                    placeholder={businessInfoFieldNames[langOption][5]}
+                    {...register("businessInfo.physicalAddress.state", { required: "State is required" })}
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    key={`physicalAddress-ZIP-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="PhysicalAddress-ZIP"
+                    placeholder={businessInfoFieldNames[langOption][6]}
+                    {...register("businessInfo.physicalAddress.zip", {
+                      required: "ZIP is required",
+                      pattern: { value: /^\d{5}$/, message: "ZIP code must be exactly 5 digits" },
+                    })}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-12 gap-2 text-[13px]">
+                <div className="col-span-10 flex items-center mt-[-8px] mb-[-8px]">
+                  <label htmlFor="sameAddress" className="flex items-center">
+                    <input
+                      type="checkbox"
+                      id="sameAddress"
+                      onChange={(e) => setIsMailingAddressSame(e.target.checked)}
+                    />
+                    {businessInfoFieldNames[langOption][8]}
+                  </label>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-12 gap-2">
+                <div className="col-span-4">
+                  <Input
+                    key={`mailingAddress-Addr-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="MailAddress-Addr"
+                    placeholder={businessInfoFieldNames[langOption][3]}
+                    {...register("businessInfo.mailingAddress.address", { required: "Address is required" })}
+                  />
+                </div>
+                <div className="col-span-3">
+                  <Input
+                    key={`mailingAddress-City-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="MailAddress-City"
+                    placeholder={businessInfoFieldNames[langOption][4]}
+                    {...register("businessInfo.mailingAddress.city", { required: "City is required" })}
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    key={`mailingAddress-State-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="MailAddress-State"
+                    placeholder={businessInfoFieldNames[langOption][5]}
+                    {...register("businessInfo.mailingAddress.state", { required: "State is required" })}
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    key={`mailingAddress-ZIP-${step}`}
+                    className="w-full border-[#8C8C8C]"
+                    type="text"
+                    id="MailAddress-ZIP"
+                    placeholder={businessInfoFieldNames[langOption][6]}
+                    {...register("businessInfo.mailingAddress.zip", { required: "ZIP is required" })}
+                  />
+                </div>
+              </div>
+
               {firstErrorMessage && <div className="text-red-600">{firstErrorMessage}</div>}
             </div>
+
             {renderNavButtons(false, false)}
           </div>
         );
@@ -543,10 +530,7 @@ const BusinessSignupApplication = () => {
                   placeholder={contactInfoFieldNames[langOption][4]}
                   {...register("contactInfo.email", {
                     required: "Email is required",
-                    pattern: {
-                      value: /^[^@]+@[^@]+$/,
-                      message: "Not in a familiar format.",
-                    },
+                    pattern: { value: /^[^@]+@[^@]+$/, message: "Not in a familiar format." },
                   })}
                 />
               </div>
@@ -566,10 +550,7 @@ const BusinessSignupApplication = () => {
                   id="Facebook"
                   placeholder="Facebook"
                   {...register("socialLinks.Facebook", {
-                    pattern: {
-                      value: /^@/,
-                      message: "Not in a familiar format.",
-                    },
+                    pattern: { value: /^@/, message: "Not in a familiar format." },
                   })}
                 />
               </div>
@@ -580,10 +561,7 @@ const BusinessSignupApplication = () => {
                   id="Instagram"
                   placeholder="Instagram"
                   {...register("socialLinks.Instagram", {
-                    pattern: {
-                      value: /^@/,
-                      message: "Not in a familiar format.",
-                    },
+                    pattern: { value: /^@/, message: "Not in a familiar format." },
                   })}
                 />
               </div>
@@ -593,12 +571,7 @@ const BusinessSignupApplication = () => {
                   type="text"
                   id="X"
                   placeholder="X"
-                  {...register("socialLinks.X", {
-                    pattern: {
-                      value: /^@/,
-                      message: "Not in a familiar format.",
-                    },
-                  })}
+                  {...register("socialLinks.X", { pattern: { value: /^@/, message: "Not in a familiar format." } })}
                 />
               </div>
             </div>
@@ -729,7 +702,7 @@ const BusinessSignupApplication = () => {
     return (
       <div className="w-[70vw] h-[300px]">
         <Card className="relative bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] rounded-lg">
-          <CardContent className="flex w-full h-[320px] mt-[15px] p-1">
+          <CardContent className="flex flex-col md:flex-row w-full h-[320px] mt-[15px] p-1">
             <div className="w-[35%] flex flex-col items-start text-left p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
               <div className="mt-[40px]">
@@ -738,7 +711,7 @@ const BusinessSignupApplication = () => {
               </div>
               {displayPaymentInfo()}
             </div>
-            <div className="w-[65%] flex justify-center">{renderStepForm()}</div>
+            <div className="w-[65%] flex justify-center mx-auto">{renderStepForm()}</div>
           </CardContent>
         </Card>
         <div className="flex flex-row justify-start">

--- a/src/components/ui/BusinessSignupApplicationCards.tsx
+++ b/src/components/ui/BusinessSignupApplicationCards.tsx
@@ -544,7 +544,7 @@ const BusinessSignupApplication = () => {
   if (step < 5) {
     return (
       <div className="w-full md:max-w-[70vw] md:h-auto">
-        <Card className="relative md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
+        <Card className="relative md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] min-h-screen md:min-h-full rounded-none md:rounded-lg">
           <CardContent className="flex flex-col md:flex-row h-full md:h-[320px] mt-[15px] p-1">
             <div className="w-auto md:w-[35%] flex flex-col items-start text-left p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />
@@ -595,8 +595,7 @@ const BusinessSignupApplication = () => {
   } else {
     return (
       <div className="w-full md:max-w-[70vw] md:h-auto">
-        <Card className="relative shadow-none md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] h-screen md:h-full rounded-none md:rounded-lg">
-          {/* <CardContent className="flex flex-col w-full h-[320px] mt-[15px] items-center"> */}
+        <Card className="relative shadow-none md:shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] min-h-screen md:min-h-full rounded-none md:rounded-lg">
           <CardContent className="md:flex-row h-full md:h-[320px] mt-[15px] items-center p-4">
             <div className="w-full flex items-start p-4">
               <Image src="/logo/HBA_NoBack_NoWords.png" alt="Logo" width={100} height={100} />


### PR DESCRIPTION
## Developer: Xavier Garcia

Closes #79 

### Pull Request Summary
This PR adds Tailwind styling for the business sign-up form. This styling reacts to window sizes on web/large screens, as well as changes for mobile views.

### Modifications
Only file: `src\components\ui\BusinessSignupApplicationCards.tsx`
Important Changes:
- Each input on the form no longer has fixed widths. The widths now are reactive to the width of the form.
- Passwords can be hidden in the entry box for them.
- Checking the box that marks the mailing address the same as the physical address hides the mailing address text fields.
- Checking and unchecking the aforementioned checkbox will flush out the mailing address info if it had previously been copied to be the physical address info.
- There are two language selectors that hide and swap places depending on if the screen is mobile (or small) or not.
- Changed the error message styling to not escape the form or overlap with components of the form.
- Miscellaneous formatting changes

### Testing Considerations
To test these changes, I would run the form locally and move from form step to form step, seeing what is visually different for my own eyes. Additionally, I would click the different buttons and inputs to cause errors to see how they look on the screen.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
There are too many parts of the form and ways to display each part to take a screenshot of each. Here is an example of one of the steps for both web and mobile views.

Web view: 
![image](https://github.com/user-attachments/assets/615323c8-8598-49a8-80d7-e8b17380a761)

Mobile view: 
![image](https://github.com/user-attachments/assets/a8a8bc0a-227f-4e5a-aa04-ea9f745f2d55)